### PR TITLE
use uint64_t instead of uint64

### DIFF
--- a/test/make_nm.cpp
+++ b/test/make_nm.cpp
@@ -30,42 +30,42 @@ using namespace Xbyak;
 
 const int bitEnd = 64;
 
-uint64 flagBit = 0;
-const uint64 WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 WSP   = 1ULL << flagBit++; /** Test vector is {wsp} */
-const uint64 XSP   = 1ULL << flagBit++; /** Test vector is {sp} */
-const uint64 WREG_WSP = WREG | WSP; 
-const uint64 XREG_XSP = XREG | XSP; 
-const uint64 IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 COND      = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
-const uint64 COND_WO_AL = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
-const uint64 NZCV       = 1ULL << flagBit++; /** Test vector is { 0, 1, ..., 15 } */
-const uint64 BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+uint64_t flagBit = 0;
+const uint64_t WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t WSP   = 1ULL << flagBit++; /** Test vector is {wsp} */
+const uint64_t XSP   = 1ULL << flagBit++; /** Test vector is {sp} */
+const uint64_t WREG_WSP = WREG | WSP;
+const uint64_t XREG_XSP = XREG | XSP;
+const uint64_t IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t COND      = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
+const uint64_t COND_WO_AL = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
+const uint64_t NZCV       = 1ULL << flagBit++; /** Test vector is { 0, 1, ..., 15 } */
+const uint64_t BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
 
 
-const uint64 NOPARA = 1ULL << (bitEnd - 1);
+const uint64_t NOPARA = 1ULL << (bitEnd - 1);
 
 
   
@@ -73,7 +73,7 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name, 0);			\
   }						\
 
@@ -81,8 +81,8 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }						\
@@ -91,9 +91,9 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -103,10 +103,10 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -117,11 +117,11 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -133,12 +133,12 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -151,13 +151,13 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -171,14 +171,14 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -193,15 +193,15 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -217,16 +217,16 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -243,22 +243,22 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -357,7 +357,7 @@ class Test {
 
 
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -367,8 +367,8 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
     for (int i = 0; i < bitEnd; i++) {
       if (op1 & (1ULL << i)) {
@@ -382,7 +382,7 @@ class Test {
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -429,7 +429,7 @@ class Test {
     */
     for(i = 0; i < num_ops; i++) {
       for(j = 0; j < bitEnd; j++) {
-	uint64 bitpos = 1ULL << j;
+	uint64_t bitpos = 1ULL << j;
 	
 	if(!(ops[i] & bitpos)) continue;
 
@@ -469,7 +469,7 @@ class Test {
     }
   }
     
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -486,7 +486,7 @@ class Test {
     return 0;
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -593,14 +593,14 @@ public:
     ss << std::hex << std::showbase;
     jss << std::hex << std::showbase;
 
-    for(uint64 onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=32-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=32-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK32.push_back(ss.str() + "<<" + std::to_string(shift));
@@ -609,14 +609,14 @@ public:
       }
     }	
     
-    for(uint64 onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=64-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=64-onesLen; shift++) {
 	ss.str("");
 	jss.str("");
 	ss << bitmask;
@@ -822,14 +822,14 @@ public:
   void putDataProcImm_BitfieldInsertAndExtract() {
     tv_SPECIFIC32.clear();
     jtv_SPECIFIC32.clear();
-    for(uint64 i=1; i<=31; i++) {
+    for(uint64_t i=1; i<=31; i++) {
       tv_SPECIFIC32.push_back(std::to_string(i) + ", " + std::to_string(32-i));
       jtv_SPECIFIC32.push_back(std::to_string(i) + ", " + std::to_string(32-i));
     }
 
     tv_SPECIFIC64.clear();
     jtv_SPECIFIC64.clear();
-    for(uint64 i=1; i<=63; i++) {
+    for(uint64_t i=1; i<=63; i++) {
       tv_SPECIFIC64.push_back(std::to_string(i) + ", " + std::to_string(64-i));
       jtv_SPECIFIC64.push_back(std::to_string(i) + ", " + std::to_string(64-i));
     }

--- a/test/make_nm_branch.cpp
+++ b/test/make_nm_branch.cpp
@@ -36,216 +36,216 @@ enum AddressingType {
 		     TP_PostReg, /** Post-indexed register */
 		     TP_None };
 
-uint64 flagBit = 0;
-const uint64 WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 XREG2  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 WSP   = flagBit++; /** Test vector is {wsp} */
-const uint64 XSP   = flagBit++; /** Test vector is {sp} */
-const uint64 XNSP  = flagBit++; 
-const uint64 XNSP2 = flagBit++; 
-const uint64 XNSP3 = flagBit++; 
+uint64_t flagBit = 0;
+const uint64_t WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t XREG2  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t WSP   = flagBit++; /** Test vector is {wsp} */
+const uint64_t XSP   = flagBit++; /** Test vector is {sp} */
+const uint64_t XNSP  = flagBit++;
+const uint64_t XNSP2 = flagBit++;
+const uint64_t XNSP3 = flagBit++;
 
-const uint64 WNZR  = flagBit++; /** Test vector is {w0, w1, ..., w30, wzr } */
-const uint64 XNZR  = flagBit++; /** Test vector is {x0, x1, ..., x30, xzr } */
+const uint64_t WNZR  = flagBit++; /** Test vector is {w0, w1, ..., w30, wzr } */
+const uint64_t XNZR  = flagBit++; /** Test vector is {x0, x1, ..., x30, xzr } */
 
-const uint64 IMM1BIT   = flagBit++; /** Test vector is {0, 1 } */
-const uint64 IMM2BIT   = flagBit++; /** Test vector is {0, 1, ..., 3 } */
-const uint64 IMM3BIT   = flagBit++; /** Test vector is {0, 1, ..., 7 } */
-const uint64 IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 31 } */
-const uint64 IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 63 } */
-const uint64 IMM7BIT   = flagBit++; /** Test vector is {0, 1, ..., 127 } */
-const uint64 IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
-const uint64 IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
-const uint64 IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
-const uint64 IMM7BIT_MUL16 = flagBit++; /** Test vector is { -256, -252, ..., 252 } */
-const uint64 IMM7BIT_PM_MUL4 = flagBit++;
-const uint64 IMM7BIT_PM_MUL8 = flagBit++;
-const uint64 IMM7BIT_PM_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
-const uint64 IMM10BIT_PM_MUL8 = flagBit++;
-const uint64 IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
-const uint64 IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
-const uint64 IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
-const uint64 IMM12BIT_MUL16 = flagBit++; /** Test vector is {0, 16, 32, ..., 65320 } */
-const uint64 IMM14BIT_MUL4 = flagBit++;
-const uint64 IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
-const uint64 IMM26BIT_MUL4 = flagBit++;
+const uint64_t IMM1BIT   = flagBit++; /** Test vector is {0, 1 } */
+const uint64_t IMM2BIT   = flagBit++; /** Test vector is {0, 1, ..., 3 } */
+const uint64_t IMM3BIT   = flagBit++; /** Test vector is {0, 1, ..., 7 } */
+const uint64_t IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 31 } */
+const uint64_t IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 63 } */
+const uint64_t IMM7BIT   = flagBit++; /** Test vector is {0, 1, ..., 127 } */
+const uint64_t IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
+const uint64_t IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
+const uint64_t IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
+const uint64_t IMM7BIT_MUL16 = flagBit++; /** Test vector is { -256, -252, ..., 252 } */
+const uint64_t IMM7BIT_PM_MUL4 = flagBit++;
+const uint64_t IMM7BIT_PM_MUL8 = flagBit++;
+const uint64_t IMM7BIT_PM_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
+const uint64_t IMM10BIT_PM_MUL8 = flagBit++;
+const uint64_t IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
+const uint64_t IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
+const uint64_t IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
+const uint64_t IMM12BIT_MUL16 = flagBit++; /** Test vector is {0, 16, 32, ..., 65320 } */
+const uint64_t IMM14BIT_MUL4 = flagBit++;
+const uint64_t IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
+const uint64_t IMM26BIT_MUL4 = flagBit++;
 
-const uint64 BREG = flagBit++; /** Test vector is { b0, b1, ..., b31 } */
-const uint64 HREG = flagBit++; /** Test vector is { h0, h1, ..., h31 } */
-const uint64 SREG = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
-const uint64 QREG = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
+const uint64_t BREG = flagBit++; /** Test vector is { b0, b1, ..., b31 } */
+const uint64_t HREG = flagBit++; /** Test vector is { h0, h1, ..., h31 } */
+const uint64_t SREG = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t QREG = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
 
-const uint64 SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC12   = flagBit++;
-const uint64 SPECIFIC13   = flagBit++;
-const uint64 SPECIFIC14   = flagBit++;
-const uint64 SPECIFIC15   = flagBit++;
-const uint64 SPECIFIC16   = flagBit++;
-const uint64 SPECIFIC17   = flagBit++;
+const uint64_t SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC12   = flagBit++;
+const uint64_t SPECIFIC13   = flagBit++;
+const uint64_t SPECIFIC14   = flagBit++;
+const uint64_t SPECIFIC15   = flagBit++;
+const uint64_t SPECIFIC16   = flagBit++;
+const uint64_t SPECIFIC17   = flagBit++;
 
-const uint64 PTR_O    = flagBit++;
-const uint64 PTR_C    = flagBit++;
+const uint64_t PTR_O    = flagBit++;
+const uint64_t PTR_C    = flagBit++;
 
-const uint64 BRA_O    = flagBit++; /** Test vector is { "{" } */
-const uint64 BRA_C    = flagBit++; /** Test vector is { "}" } */
+const uint64_t BRA_O    = flagBit++; /** Test vector is { "{" } */
+const uint64_t BRA_C    = flagBit++; /** Test vector is { "}" } */
 
-const uint64 PAR_O    = flagBit++; /** Test vector is { "(" } */
-const uint64 PAR_C    = flagBit++; /** Test vector is { ">" } */
+const uint64_t PAR_O    = flagBit++; /** Test vector is { "(" } */
+const uint64_t PAR_C    = flagBit++; /** Test vector is { ">" } */
 
-const uint64 PRE_PTR_O    = flagBit++; /** Test vector is { "[" } or { "pre_ptr(" } */
-const uint64 PRE_PTR_C    = flagBit++; /** Test vector is { "]!" } or { ")" } */
+const uint64_t PRE_PTR_O    = flagBit++; /** Test vector is { "[" } or { "pre_ptr(" } */
+const uint64_t PRE_PTR_C    = flagBit++; /** Test vector is { "]!" } or { ")" } */
 
-//const uint64 POST_PTR  = flagBit++;
-
-
-const uint64 T_LSL      = flagBit++; /** Test vector is { "LSL" } */ 
-const uint64 T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
-const uint64 T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
-const uint64 T_SXTX     =  flagBit++; /** Test vector is { "SXTX", "SXT" } */
-
-const uint64 IMM_0      =  flagBit++; /** Test vector is { "0" } */
-const uint64 IMM_0_OR_1  =  flagBit++; /** Test vector is { "0", "1" } */
-const uint64 IMM_0_OR_2  =  flagBit++; /** Test vector is { "0", "2" } */
-const uint64 IMM_0_OR_3  =  flagBit++; /** Test vector is { "0", "3" } */
-const uint64 IMM_0_OR_4  =  flagBit++; /** Test vector is { "0", "4" } */
-const uint64 IMM_2       =  flagBit++;
-const uint64 IMM_4       =  flagBit++;
-const uint64 IMM_8       =  flagBit++;
-const uint64 IMM_16      =  flagBit++;
-const uint64 IMM_8_OR_16 =  flagBit++; /** Test vector is { "8", "16" } */
-const uint64 IMM_16_OR_32 =  flagBit++;
-const uint64 IMM_24_OR_48 =  flagBit++;
-const uint64 IMM_32_OR_64 =  flagBit++;
-
-const uint64 VREGB_1D    = flagBit++;
-const uint64 VREGH_1D    = flagBit++;
-const uint64 VREGS_1D    = flagBit++;
-const uint64 VREGD_1D    = flagBit++;
-const uint64 VREGB_2D    = flagBit++;
-const uint64 VREGH_2D    = flagBit++;
-const uint64 VREGS_2D    = flagBit++;
-const uint64 VREGD_2D    = flagBit++;
-const uint64 VREGB_3D    = flagBit++;
-const uint64 VREGH_3D    = flagBit++;
-const uint64 VREGS_3D    = flagBit++;
-const uint64 VREGD_3D    = flagBit++;
-const uint64 VREGB_4D    = flagBit++;
-const uint64 VREGH_4D    = flagBit++;
-const uint64 VREGS_4D    = flagBit++;
-const uint64 VREGD_4D    = flagBit++;
-
-const uint64 VREG16B_1D  = flagBit++;
-const uint64 VREG8B_1D   = flagBit++;
-const uint64 VREG8H_1D   = flagBit++;
-const uint64 VREG4H_1D   = flagBit++;
-const uint64 VREG4S_1D   = flagBit++;
-const uint64 VREG2S_1D   = flagBit++;
-const uint64 VREG2D_1D   = flagBit++;
-const uint64 VREG1D_1D   = flagBit++;
-const uint64 VREG16B_2D  = flagBit++;
-const uint64 VREG8B_2D   = flagBit++;
-const uint64 VREG8H_2D   = flagBit++;
-const uint64 VREG4H_2D   = flagBit++;
-const uint64 VREG4S_2D   = flagBit++;
-const uint64 VREG2S_2D   = flagBit++;
-const uint64 VREG2D_2D   = flagBit++;
-const uint64 VREG1D_2D   = flagBit++;
-const uint64 VREG16B_3D  = flagBit++;
-const uint64 VREG8B_3D   = flagBit++;
-const uint64 VREG8H_3D   = flagBit++;
-const uint64 VREG4H_3D   = flagBit++;
-const uint64 VREG4S_3D   = flagBit++;
-const uint64 VREG2S_3D   = flagBit++;
-const uint64 VREG2D_3D   = flagBit++;
-const uint64 VREG1D_3D   = flagBit++;
-const uint64 VREG16B_4D  = flagBit++;
-const uint64 VREG8B_4D   = flagBit++;
-const uint64 VREG8H_4D   = flagBit++;
-const uint64 VREG4H_4D   = flagBit++;
-const uint64 VREG4S_4D   = flagBit++;
-const uint64 VREG2S_4D   = flagBit++;
-const uint64 VREG2D_4D   = flagBit++;
-const uint64 VREG1D_4D   = flagBit++;
-
-const uint64 VREGB_1D_ELEM    = flagBit++;
-const uint64 VREGH_1D_ELEM    = flagBit++;
-const uint64 VREGS_1D_ELEM    = flagBit++;
-const uint64 VREGD_1D_ELEM    = flagBit++;
-const uint64 VREGB_2D_ELEM    = flagBit++;
-const uint64 VREGH_2D_ELEM    = flagBit++;
-const uint64 VREGS_2D_ELEM    = flagBit++;
-const uint64 VREGD_2D_ELEM    = flagBit++;
-const uint64 VREGB_3D_ELEM    = flagBit++;
-const uint64 VREGH_3D_ELEM    = flagBit++;
-const uint64 VREGS_3D_ELEM    = flagBit++;
-const uint64 VREGD_3D_ELEM    = flagBit++;
-const uint64 VREGB_4D_ELEM    = flagBit++;
-const uint64 VREGH_4D_ELEM    = flagBit++;
-const uint64 VREGS_4D_ELEM    = flagBit++;
-const uint64 VREGD_4D_ELEM    = flagBit++;
-
-const uint64 VREG16B_1D_ELEM  = flagBit++;
-const uint64 VREG8B_1D_ELEM   = flagBit++;
-const uint64 VREG8H_1D_ELEM   = flagBit++;
-const uint64 VREG4H_1D_ELEM   = flagBit++;
-const uint64 VREG4S_1D_ELEM   = flagBit++;
-const uint64 VREG2S_1D_ELEM   = flagBit++;
-const uint64 VREG2D_1D_ELEM   = flagBit++;
-const uint64 VREG1D_1D_ELEM   = flagBit++;
-const uint64 VREG16B_2D_ELEM  = flagBit++;
-const uint64 VREG8B_2D_ELEM   = flagBit++;
-const uint64 VREG8H_2D_ELEM   = flagBit++;
-const uint64 VREG4H_2D_ELEM   = flagBit++;
-const uint64 VREG4S_2D_ELEM   = flagBit++;
-const uint64 VREG2S_2D_ELEM   = flagBit++;
-const uint64 VREG2D_2D_ELEM   = flagBit++;
-const uint64 VREG1D_2D_ELEM   = flagBit++;
-const uint64 VREG16B_3D_ELEM  = flagBit++;
-const uint64 VREG8B_3D_ELEM   = flagBit++;
-const uint64 VREG8H_3D_ELEM   = flagBit++;
-const uint64 VREG4H_3D_ELEM   = flagBit++;
-const uint64 VREG4S_3D_ELEM   = flagBit++;
-const uint64 VREG2S_3D_ELEM   = flagBit++;
-const uint64 VREG2D_3D_ELEM   = flagBit++;
-const uint64 VREG1D_3D_ELEM   = flagBit++;
-const uint64 VREG16B_4D_ELEM  = flagBit++;
-const uint64 VREG8B_4D_ELEM   = flagBit++;
-const uint64 VREG8H_4D_ELEM   = flagBit++;
-const uint64 VREG4H_4D_ELEM   = flagBit++;
-const uint64 VREG4S_4D_ELEM   = flagBit++;
-const uint64 VREG2S_4D_ELEM   = flagBit++;
-const uint64 VREG2D_4D_ELEM   = flagBit++;
-const uint64 VREG1D_4D_ELEM   = flagBit++;
-
-const uint64 PRFOP            = flagBit++;
-const uint64 BARRIER              = flagBit++;
+//const uint64_t POST_PTR  = flagBit++;
 
 
-const uint64 NOPARA = 100000;
+const uint64_t T_LSL      = flagBit++; /** Test vector is { "LSL" } */
+const uint64_t T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
+const uint64_t T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
+const uint64_t T_SXTX     =  flagBit++; /** Test vector is { "SXTX", "SXT" } */
+
+const uint64_t IMM_0      =  flagBit++; /** Test vector is { "0" } */
+const uint64_t IMM_0_OR_1  =  flagBit++; /** Test vector is { "0", "1" } */
+const uint64_t IMM_0_OR_2  =  flagBit++; /** Test vector is { "0", "2" } */
+const uint64_t IMM_0_OR_3  =  flagBit++; /** Test vector is { "0", "3" } */
+const uint64_t IMM_0_OR_4  =  flagBit++; /** Test vector is { "0", "4" } */
+const uint64_t IMM_2       =  flagBit++;
+const uint64_t IMM_4       =  flagBit++;
+const uint64_t IMM_8       =  flagBit++;
+const uint64_t IMM_16      =  flagBit++;
+const uint64_t IMM_8_OR_16 =  flagBit++; /** Test vector is { "8", "16" } */
+const uint64_t IMM_16_OR_32 =  flagBit++;
+const uint64_t IMM_24_OR_48 =  flagBit++;
+const uint64_t IMM_32_OR_64 =  flagBit++;
+
+const uint64_t VREGB_1D    = flagBit++;
+const uint64_t VREGH_1D    = flagBit++;
+const uint64_t VREGS_1D    = flagBit++;
+const uint64_t VREGD_1D    = flagBit++;
+const uint64_t VREGB_2D    = flagBit++;
+const uint64_t VREGH_2D    = flagBit++;
+const uint64_t VREGS_2D    = flagBit++;
+const uint64_t VREGD_2D    = flagBit++;
+const uint64_t VREGB_3D    = flagBit++;
+const uint64_t VREGH_3D    = flagBit++;
+const uint64_t VREGS_3D    = flagBit++;
+const uint64_t VREGD_3D    = flagBit++;
+const uint64_t VREGB_4D    = flagBit++;
+const uint64_t VREGH_4D    = flagBit++;
+const uint64_t VREGS_4D    = flagBit++;
+const uint64_t VREGD_4D    = flagBit++;
+
+const uint64_t VREG16B_1D  = flagBit++;
+const uint64_t VREG8B_1D   = flagBit++;
+const uint64_t VREG8H_1D   = flagBit++;
+const uint64_t VREG4H_1D   = flagBit++;
+const uint64_t VREG4S_1D   = flagBit++;
+const uint64_t VREG2S_1D   = flagBit++;
+const uint64_t VREG2D_1D   = flagBit++;
+const uint64_t VREG1D_1D   = flagBit++;
+const uint64_t VREG16B_2D  = flagBit++;
+const uint64_t VREG8B_2D   = flagBit++;
+const uint64_t VREG8H_2D   = flagBit++;
+const uint64_t VREG4H_2D   = flagBit++;
+const uint64_t VREG4S_2D   = flagBit++;
+const uint64_t VREG2S_2D   = flagBit++;
+const uint64_t VREG2D_2D   = flagBit++;
+const uint64_t VREG1D_2D   = flagBit++;
+const uint64_t VREG16B_3D  = flagBit++;
+const uint64_t VREG8B_3D   = flagBit++;
+const uint64_t VREG8H_3D   = flagBit++;
+const uint64_t VREG4H_3D   = flagBit++;
+const uint64_t VREG4S_3D   = flagBit++;
+const uint64_t VREG2S_3D   = flagBit++;
+const uint64_t VREG2D_3D   = flagBit++;
+const uint64_t VREG1D_3D   = flagBit++;
+const uint64_t VREG16B_4D  = flagBit++;
+const uint64_t VREG8B_4D   = flagBit++;
+const uint64_t VREG8H_4D   = flagBit++;
+const uint64_t VREG4H_4D   = flagBit++;
+const uint64_t VREG4S_4D   = flagBit++;
+const uint64_t VREG2S_4D   = flagBit++;
+const uint64_t VREG2D_4D   = flagBit++;
+const uint64_t VREG1D_4D   = flagBit++;
+
+const uint64_t VREGB_1D_ELEM    = flagBit++;
+const uint64_t VREGH_1D_ELEM    = flagBit++;
+const uint64_t VREGS_1D_ELEM    = flagBit++;
+const uint64_t VREGD_1D_ELEM    = flagBit++;
+const uint64_t VREGB_2D_ELEM    = flagBit++;
+const uint64_t VREGH_2D_ELEM    = flagBit++;
+const uint64_t VREGS_2D_ELEM    = flagBit++;
+const uint64_t VREGD_2D_ELEM    = flagBit++;
+const uint64_t VREGB_3D_ELEM    = flagBit++;
+const uint64_t VREGH_3D_ELEM    = flagBit++;
+const uint64_t VREGS_3D_ELEM    = flagBit++;
+const uint64_t VREGD_3D_ELEM    = flagBit++;
+const uint64_t VREGB_4D_ELEM    = flagBit++;
+const uint64_t VREGH_4D_ELEM    = flagBit++;
+const uint64_t VREGS_4D_ELEM    = flagBit++;
+const uint64_t VREGD_4D_ELEM    = flagBit++;
+
+const uint64_t VREG16B_1D_ELEM  = flagBit++;
+const uint64_t VREG8B_1D_ELEM   = flagBit++;
+const uint64_t VREG8H_1D_ELEM   = flagBit++;
+const uint64_t VREG4H_1D_ELEM   = flagBit++;
+const uint64_t VREG4S_1D_ELEM   = flagBit++;
+const uint64_t VREG2S_1D_ELEM   = flagBit++;
+const uint64_t VREG2D_1D_ELEM   = flagBit++;
+const uint64_t VREG1D_1D_ELEM   = flagBit++;
+const uint64_t VREG16B_2D_ELEM  = flagBit++;
+const uint64_t VREG8B_2D_ELEM   = flagBit++;
+const uint64_t VREG8H_2D_ELEM   = flagBit++;
+const uint64_t VREG4H_2D_ELEM   = flagBit++;
+const uint64_t VREG4S_2D_ELEM   = flagBit++;
+const uint64_t VREG2S_2D_ELEM   = flagBit++;
+const uint64_t VREG2D_2D_ELEM   = flagBit++;
+const uint64_t VREG1D_2D_ELEM   = flagBit++;
+const uint64_t VREG16B_3D_ELEM  = flagBit++;
+const uint64_t VREG8B_3D_ELEM   = flagBit++;
+const uint64_t VREG8H_3D_ELEM   = flagBit++;
+const uint64_t VREG4H_3D_ELEM   = flagBit++;
+const uint64_t VREG4S_3D_ELEM   = flagBit++;
+const uint64_t VREG2S_3D_ELEM   = flagBit++;
+const uint64_t VREG2D_3D_ELEM   = flagBit++;
+const uint64_t VREG1D_3D_ELEM   = flagBit++;
+const uint64_t VREG16B_4D_ELEM  = flagBit++;
+const uint64_t VREG8B_4D_ELEM   = flagBit++;
+const uint64_t VREG8H_4D_ELEM   = flagBit++;
+const uint64_t VREG4H_4D_ELEM   = flagBit++;
+const uint64_t VREG4S_4D_ELEM   = flagBit++;
+const uint64_t VREG2S_4D_ELEM   = flagBit++;
+const uint64_t VREG2D_4D_ELEM   = flagBit++;
+const uint64_t VREG1D_4D_ELEM   = flagBit++;
+
+const uint64_t PRFOP            = flagBit++;
+const uint64_t BARRIER              = flagBit++;
+
+
+const uint64_t NOPARA = 100000;
 
 
 #define PUT0(name, nm)				\
@@ -259,7 +259,7 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name, 0);			\
   }						\
 
@@ -267,8 +267,8 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }						\
@@ -277,9 +277,9 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -289,10 +289,10 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -303,11 +303,11 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -319,12 +319,12 @@ const uint64 NOPARA = 100000;
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -337,13 +337,13 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -357,14 +357,14 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -379,15 +379,15 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -403,16 +403,16 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -429,22 +429,22 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -772,7 +772,7 @@ class Test {
     }
   }
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -782,14 +782,14 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
-    return get(op1, (uint64) 0);
+    return get(op1, (uint64_t) 0);
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -897,7 +897,7 @@ class Test {
     }
   }
 
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -906,7 +906,7 @@ class Test {
     return tv_Vectors[type]->size();
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;

--- a/test/make_nm_fp.cpp
+++ b/test/make_nm_fp.cpp
@@ -30,55 +30,55 @@ using namespace Xbyak;
 
 const int bitEnd = 64;
 /** Begin:Really used in this file. */
-uint64 flagBit = 0;
-const uint64 WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 WSP   = 1ULL << flagBit++; /** Test vector is {wsp} */
-const uint64 XSP   = 1ULL << flagBit++; /** Test vector is {sp} */
-const uint64 WREG_WSP = WREG | WSP; 
-const uint64 XREG_XSP = XREG | XSP; 
-const uint64 IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
-const uint64 IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {0, 1, 2, .., 32 } */
-const uint64 IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {0, 1, 2, .., 64 } */
-const uint64 FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
-const uint64 COND      = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
-const uint64 COND_WO_AL = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
-const uint64 NZCV       = 1ULL << flagBit++; /** Test vector is { 0, 1, ..., 15 } */
+uint64_t flagBit = 0;
+const uint64_t WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t WSP   = 1ULL << flagBit++; /** Test vector is {wsp} */
+const uint64_t XSP   = 1ULL << flagBit++; /** Test vector is {sp} */
+const uint64_t WREG_WSP = WREG | WSP;
+const uint64_t XREG_XSP = XREG | XSP;
+const uint64_t IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
+const uint64_t IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {0, 1, 2, .., 32 } */
+const uint64_t IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {0, 1, 2, .., 64 } */
+const uint64_t FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
+const uint64_t COND      = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
+const uint64_t COND_WO_AL = 1ULL << flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
+const uint64_t NZCV       = 1ULL << flagBit++; /** Test vector is { 0, 1, ..., 15 } */
 
-const uint64 BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
-const uint64 HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
-const uint64 SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
+const uint64_t HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
+const uint64_t SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
 
-const uint64 BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 VREG_ELEM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t VREG_ELEM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
 
 
 
-const uint64 NOPARA = 1ULL << (bitEnd - 1);
+const uint64_t NOPARA = 1ULL << (bitEnd - 1);
 
 
   
@@ -86,7 +86,7 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name);					\
   }						\
 
@@ -94,8 +94,8 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
   }						\
@@ -104,9 +104,9 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -116,10 +116,10 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -130,11 +130,11 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -146,12 +146,12 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name);						\
     put(nemonic, op2, #name);						\
     put(nemonic, op3, #name);						\
@@ -164,13 +164,13 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name);							\
     put(nemonic, op2, #name);							\
     put(nemonic, op3, #name);							\
@@ -184,14 +184,14 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name);							\
     put(nemonic, op2, #name);							\
     put(nemonic, op3, #name);							\
@@ -301,7 +301,7 @@ class Test {
 
 
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name) const
   {
     std::cout << "//" << name << std::endl; /** For easy debug */
     
@@ -311,8 +311,8 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
     for (int i = 0; i < bitEnd; i++) {
       if (op1 & (1ULL << i)) {
@@ -326,7 +326,7 @@ class Test {
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -373,7 +373,7 @@ class Test {
     */
     for(i = 0; i < num_ops; i++) {
       for(j = 0; j < bitEnd; j++) {
-	uint64 bitpos = 1ULL << j;
+	uint64_t bitpos = 1ULL << j;
 	
 	if(!(ops[i] & bitpos)) continue;
 
@@ -413,7 +413,7 @@ class Test {
     }
   }
     
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -430,7 +430,7 @@ class Test {
     return 0;
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -535,14 +535,14 @@ public:
     std::stringstream ss;
     ss << std::hex << std::showbase;
 
-    for(uint64 onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=32-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=32-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK32.push_back(ss.str() + "<<" + std::to_string(shift));
@@ -550,14 +550,14 @@ public:
       }
     }	
     
-    for(uint64 onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=64-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=64-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK64.push_back(ss.str() + "<<" + std::to_string(shift));

--- a/test/make_nm_load_store.cpp
+++ b/test/make_nm_load_store.cpp
@@ -36,86 +36,86 @@ enum AddressingType {
 		     TP_PostReg, /** Post-indexed register */
 		     TP_None };
 
-uint64 flagBit = 0;
-const uint64 WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 WREG3 = flagBit++;
-const uint64 XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 XREG2 = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 XREG3 = flagBit++; 
-const uint64 WSP   = flagBit++; /** Test vector is {wsp} */
-const uint64 XSP   = flagBit++; /** Test vector is {sp} */
-const uint64 XNSP  = flagBit++;
-const uint64 XNSP2 = flagBit++;
-const uint64 XNSP3 = flagBit++; 
-const uint64 IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
-const uint64 IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
-const uint64 IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
-const uint64 IMM7BIT_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
-const uint64 IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
-const uint64 IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
-const uint64 IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
-const uint64 IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
-const uint64 COND      = flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
-const uint64 COND_WO_AL = flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
-const uint64 NZCV       = flagBit++; /** Test vector is { 0, 1, ..., 15 } */
-const uint64 BITMASK32  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 BITMASK64  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 LSL_IMM    = flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL32 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL64 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 IMM_0_OR_1   = flagBit++; /** Test vector is { "0", "1" }; */
-const uint64 IMM_0_OR_2   = flagBit++; /** Test vector is { "0", "2" }; */
-const uint64 SHIFT_AMOUNT32    = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT64    = flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT32    = flagBit++; /** Test vector is generated on the fly. */
-const uint64 EXT_AMOUNT64    = flagBit++; /** Test vector is generated on the fly. */
+uint64_t flagBit = 0;
+const uint64_t WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t WREG3 = flagBit++;
+const uint64_t XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t XREG2 = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t XREG3 = flagBit++;
+const uint64_t WSP   = flagBit++; /** Test vector is {wsp} */
+const uint64_t XSP   = flagBit++; /** Test vector is {sp} */
+const uint64_t XNSP  = flagBit++;
+const uint64_t XNSP2 = flagBit++;
+const uint64_t XNSP3 = flagBit++;
+const uint64_t IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
+const uint64_t IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
+const uint64_t IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
+const uint64_t IMM7BIT_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
+const uint64_t IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
+const uint64_t IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
+const uint64_t IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
+const uint64_t IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
+const uint64_t COND      = flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE, AL } */
+const uint64_t COND_WO_AL = flagBit++; /** Test vector is { EQ, NE, CS, CC, MI, PL, VS, VC, HI, LS, GE, LT, GT, LE } */
+const uint64_t NZCV       = flagBit++; /** Test vector is { 0, 1, ..., 15 } */
+const uint64_t BITMASK32  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t BITMASK64  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t LSL_IMM    = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL32 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL64 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t IMM_0_OR_1   = flagBit++; /** Test vector is { "0", "1" }; */
+const uint64_t IMM_0_OR_2   = flagBit++; /** Test vector is { "0", "2" }; */
+const uint64_t SHIFT_AMOUNT32    = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT64    = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT32    = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t EXT_AMOUNT64    = flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 PTR_O    = flagBit++;
-const uint64 PTR_C    = flagBit++;
+const uint64_t PTR_O    = flagBit++;
+const uint64_t PTR_C    = flagBit++;
 
-const uint64 BRA_O    = flagBit++; /** Test vector is { "{" } */
-const uint64 BRA_C    = flagBit++; /** Test vector is { "}" } */
+const uint64_t BRA_O    = flagBit++; /** Test vector is { "{" } */
+const uint64_t BRA_C    = flagBit++; /** Test vector is { "}" } */
 
-const uint64 PAR_O    = flagBit++; /** Test vector is { "(" } */
-const uint64 PAR_C    = flagBit++; /** Test vector is { ">" } */
+const uint64_t PAR_O    = flagBit++; /** Test vector is { "(" } */
+const uint64_t PAR_C    = flagBit++; /** Test vector is { ">" } */
 
-//const uint64 POST_PTR  = flagBit++;
-
-
-const uint64 T_LSL      = flagBit++; /** Test vector is { "LSL" } */ 
-const uint64 T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
-const uint64 T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
-const uint64 T_SXTX     = flagBit++; /** Test vector is { "SXTX", "SXT" } */
+//const uint64_t POST_PTR  = flagBit++;
 
 
+const uint64_t T_LSL      = flagBit++; /** Test vector is { "LSL" } */
+const uint64_t T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
+const uint64_t T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
+const uint64_t T_SXTX     = flagBit++; /** Test vector is { "SXTX", "SXT" } */
 
-const uint64 NOPARA = 100000;
+
+
+const uint64_t NOPARA = 100000;
 
 
 #define PUT0(name, nm)				\
@@ -129,7 +129,7 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name, 0);			\
   }						\
 
@@ -137,8 +137,8 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }						\
@@ -147,9 +147,9 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -159,10 +159,10 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -173,11 +173,11 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -189,12 +189,12 @@ const uint64 NOPARA = 100000;
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -207,13 +207,13 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -227,14 +227,14 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -249,15 +249,15 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -273,16 +273,16 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -299,22 +299,22 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -512,7 +512,7 @@ class Test {
     }
   }
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -522,14 +522,14 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
-    return get(op1, (uint64) 0);
+    return get(op1, (uint64_t) 0);
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -637,7 +637,7 @@ class Test {
       }
     }
 
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -646,7 +646,7 @@ class Test {
     return tv_Vectors[type]->size();
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -740,14 +740,14 @@ class Test {
     std::stringstream ss;
     ss << std::hex << std::showbase;
 
-    for(uint64 onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=32-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=32-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK32.push_back(ss.str() + "<<" + std::to_string(shift));
@@ -755,14 +755,14 @@ class Test {
       }
     }	
     
-    for(uint64 onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=64-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=64-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK64.push_back(ss.str() + "<<" + std::to_string(shift));

--- a/test/make_nm_simd.cpp
+++ b/test/make_nm_simd.cpp
@@ -30,75 +30,75 @@ using namespace Xbyak;
 
 const int bitEnd = 64;
 /** Begin:Really used in this file. */
-uint64 flagBit = 0;
-const uint64 WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 VREG  = 1ULL << flagBit++; /** Test vector is {v0, v1, ..., v31 } */
-const uint64 IMM0BIT   = 1ULL << flagBit++; /** Test vector is {0} */
-const uint64 IMM1BIT   = 1ULL << flagBit++; /** Test vector is {0, 1} */
-const uint64 IMM2BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 3 } */
-const uint64 IMM3BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
-const uint64 IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
-const uint64 IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM3BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 8 } */
-const uint64 IMM4BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 16 } */
-const uint64 IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 32 } */
-const uint64 IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 64 } */
-const uint64 FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
+uint64_t flagBit = 0;
+const uint64_t WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t VREG  = 1ULL << flagBit++; /** Test vector is {v0, v1, ..., v31 } */
+const uint64_t IMM0BIT   = 1ULL << flagBit++; /** Test vector is {0} */
+const uint64_t IMM1BIT   = 1ULL << flagBit++; /** Test vector is {0, 1} */
+const uint64_t IMM2BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 3 } */
+const uint64_t IMM3BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
+const uint64_t IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
+const uint64_t IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM3BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 8 } */
+const uint64_t IMM4BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 16 } */
+const uint64_t IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 32 } */
+const uint64_t IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 64 } */
+const uint64_t FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
 
-const uint64 BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
-const uint64 HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
-const uint64 SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
-const uint64 QREG = 1ULL << flagBit++; /** Test vector is { q0, q1, ..., q31 } */
+const uint64_t BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
+const uint64_t HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
+const uint64_t SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t QREG = 1ULL << flagBit++; /** Test vector is { q0, q1, ..., q31 } */
 
-const uint64 BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t BITMASK32  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t BITMASK64  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t LSL_IMM    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t LSL64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT32    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SHIFT_AMOUNT64    = 1ULL << flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 VREG_8B  = 1ULL << flagBit++; /** Test vector is { v0.8b, v1.8b, ..., v31.8b } */
-const uint64 VREG_16B = 1ULL << flagBit++;  /** Test vector is { v0.16b, v1.16b, ..., v31.16b } */
-const uint64 VREG_2H  = 1ULL << flagBit++;  /** Test vector is { v0.2h, v1.2h, ..., v31.2h } */
-const uint64 VREG_4H  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_8H  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_2S  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_4S  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_1D  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_2D  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
-const uint64 VREG_1Q  = 1ULL << flagBit++;  /** Test vector is { v0.1q, v1.1q, ..., v31.1q } */
+const uint64_t VREG_8B  = 1ULL << flagBit++; /** Test vector is { v0.8b, v1.8b, ..., v31.8b } */
+const uint64_t VREG_16B = 1ULL << flagBit++;  /** Test vector is { v0.16b, v1.16b, ..., v31.16b } */
+const uint64_t VREG_2H  = 1ULL << flagBit++;  /** Test vector is { v0.2h, v1.2h, ..., v31.2h } */
+const uint64_t VREG_4H  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_8H  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_2S  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_4S  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_1D  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_2D  = 1ULL << flagBit++;  /** Test vector is { v0.b, v1.b, ..., v31.b } */
+const uint64_t VREG_1Q  = 1ULL << flagBit++;  /** Test vector is { v0.1q, v1.1q, ..., v31.1q } */
 
-const uint64 VREG_8B_ELEM  = 1ULL << flagBit++;
-const uint64 VREG_16B_ELEM = 1ULL << flagBit++;
-const uint64 VREG_4H_ELEM = 1ULL << flagBit++;
-const uint64 VREG_8H_ELEM  = 1ULL << flagBit++;
-const uint64 VREG_2S_ELEM  = 1ULL << flagBit++;
-const uint64 VREG_4S_ELEM  = 1ULL << flagBit++;
-const uint64 VREG_1D_ELEM  = 1ULL << flagBit++;
-const uint64 VREG_2D_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_8B_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_16B_ELEM = 1ULL << flagBit++;
+const uint64_t VREG_4H_ELEM = 1ULL << flagBit++;
+const uint64_t VREG_8H_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_2S_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_4S_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_1D_ELEM  = 1ULL << flagBit++;
+const uint64_t VREG_2D_ELEM  = 1ULL << flagBit++;
 
-const uint64 VREG_B_ELEM = VREG_16B_ELEM;
-const uint64 VREG_H_ELEM = VREG_8H_ELEM;
-const uint64 VREG_S_ELEM = VREG_4S_ELEM;
-const uint64 VREG_D_ELEM = VREG_2D_ELEM;
+const uint64_t VREG_B_ELEM = VREG_16B_ELEM;
+const uint64_t VREG_H_ELEM = VREG_8H_ELEM;
+const uint64_t VREG_S_ELEM = VREG_4S_ELEM;
+const uint64_t VREG_D_ELEM = VREG_2D_ELEM;
 
-const uint64 NOPARA = 1ULL << (bitEnd - 1);
+const uint64_t NOPARA = 1ULL << (bitEnd - 1);
 
 
   
@@ -106,7 +106,7 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name, 0);			\
   }						\
 
@@ -114,8 +114,8 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }						\
@@ -124,9 +124,9 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -136,10 +136,10 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -150,11 +150,11 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -166,12 +166,12 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -184,13 +184,13 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -204,14 +204,14 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -226,15 +226,15 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -250,16 +250,16 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -276,22 +276,22 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -479,7 +479,7 @@ class Test {
 
 
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -489,8 +489,8 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
     for (int i = 0; i < bitEnd; i++) {
       if (op1 & (1ULL << i)) {
@@ -504,7 +504,7 @@ class Test {
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -551,7 +551,7 @@ class Test {
     */
     for(i = 0; i < num_ops; i++) {
       for(j = 0; j < bitEnd; j++) {
-	uint64 bitpos = 1ULL << j;
+	uint64_t bitpos = 1ULL << j;
 	
 	if(!(ops[i] & bitpos)) continue;
 
@@ -591,7 +591,7 @@ class Test {
     }
   }
     
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -608,7 +608,7 @@ class Test {
     return 0;
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -713,14 +713,14 @@ public:
     std::stringstream ss;
     ss << std::hex << std::showbase;
 
-    for(uint64 onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=31; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=32-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=32-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK32.push_back(ss.str() + "<<" + std::to_string(shift));
@@ -728,14 +728,14 @@ public:
       }
     }	
     
-    for(uint64 onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
-      uint64 bitmask = 0;
+    for(uint64_t onesLen=1; onesLen<=63; onesLen++) { // Inall-one bit is reserved.
+      uint64_t bitmask = 0;
 
-      for(uint64 i=1; i<=onesLen; i++) {
+      for(uint64_t i=1; i<=onesLen; i++) {
 	bitmask = (bitmask<<1) + 1;
       }
 
-      for(uint64 shift=0; shift<=64-onesLen; shift++) {
+      for(uint64_t shift=0; shift<=64-onesLen; shift++) {
 	ss.str("");
 	ss << bitmask;
 	tv_BITMASK64.push_back(ss.str() + "<<" + std::to_string(shift));

--- a/test/make_nm_simd_fp_load_store.cpp
+++ b/test/make_nm_simd_fp_load_store.cpp
@@ -36,209 +36,209 @@ enum AddressingType {
 		     TP_PostReg, /** Post-indexed register */
 		     TP_None };
 
-uint64 flagBit = 0;
-const uint64 WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 XREG2  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 WSP   = flagBit++; /** Test vector is {wsp} */
-const uint64 XSP   = flagBit++; /** Test vector is {sp} */
-const uint64 XNSP  = flagBit++; 
-const uint64 XNSP2 = flagBit++; 
-const uint64 IMM1BIT   = flagBit++; /** Test vector is {0, 1 } */
-const uint64 IMM2BIT   = flagBit++; /** Test vector is {0, 1, ..., 3 } */
-const uint64 IMM3BIT   = flagBit++; /** Test vector is {0, 1, ..., 7 } */
-const uint64 IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 31 } */
-const uint64 IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
-const uint64 IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
-const uint64 IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
-const uint64 IMM7BIT_MUL16 = flagBit++; /** Test vector is { -256, -252, ..., 252 } */
-const uint64 IMM7BIT_PM_MUL4 = flagBit++;
-const uint64 IMM7BIT_PM_MUL8 = flagBit++;
-const uint64 IMM7BIT_PM_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
-const uint64 IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
-const uint64 IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
-const uint64 IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
-const uint64 IMM12BIT_MUL16 = flagBit++; /** Test vector is {0, 16, 32, ..., 65320 } */
-const uint64 IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
+uint64_t flagBit = 0;
+const uint64_t WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t XREG2  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t WSP   = flagBit++; /** Test vector is {wsp} */
+const uint64_t XSP   = flagBit++; /** Test vector is {sp} */
+const uint64_t XNSP  = flagBit++;
+const uint64_t XNSP2 = flagBit++;
+const uint64_t IMM1BIT   = flagBit++; /** Test vector is {0, 1 } */
+const uint64_t IMM2BIT   = flagBit++; /** Test vector is {0, 1, ..., 3 } */
+const uint64_t IMM3BIT   = flagBit++; /** Test vector is {0, 1, ..., 7 } */
+const uint64_t IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 31 } */
+const uint64_t IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM9BIT_PM = flagBit++; /** Test vector is {-256, -255, ..., 255 } */
+const uint64_t IMM7BIT_MUL4 = flagBit++; /** Test vector is { 0, 4, 8, ..., 127*4 } */
+const uint64_t IMM7BIT_MUL8 = flagBit++; /** Test vector is { 0, 8, 16, ..., 127*8 } */
+const uint64_t IMM7BIT_MUL16 = flagBit++; /** Test vector is { -256, -252, ..., 252 } */
+const uint64_t IMM7BIT_PM_MUL4 = flagBit++;
+const uint64_t IMM7BIT_PM_MUL8 = flagBit++;
+const uint64_t IMM7BIT_PM_MUL16 = flagBit++; /** Test vector is { 0, 16, 32, ..., 127*16 } */
+const uint64_t IMM12BIT_MUL2 = flagBit++; /** Test vector is {0, 4, 8, ..., 8190 } */
+const uint64_t IMM12BIT_MUL4 = flagBit++; /** Test vector is {0, 4, 8, ..., 16380 } */
+const uint64_t IMM12BIT_MUL8 = flagBit++; /** Test vector is {0, 8, 16, ..., 32760 } */
+const uint64_t IMM12BIT_MUL16 = flagBit++; /** Test vector is {0, 16, 32, ..., 65320 } */
+const uint64_t IMM19BIT_MUL4 = flagBit++; /** Test vector is {-2^19*4, ...., (2^19-1)*4 } */
 
-const uint64 BREG = flagBit++; /** Test vector is { b0, b1, ..., b31 } */
-const uint64 HREG = flagBit++; /** Test vector is { h0, h1, ..., h31 } */
-const uint64 SREG = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
-const uint64 QREG = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
+const uint64_t BREG = flagBit++; /** Test vector is { b0, b1, ..., b31 } */
+const uint64_t HREG = flagBit++; /** Test vector is { h0, h1, ..., h31 } */
+const uint64_t SREG = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t QREG = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
 
-const uint64 SREG2 = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG2 = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
-const uint64 QREG2 = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
+const uint64_t SREG2 = flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG2 = flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t QREG2 = flagBit++; /** Test vector is { q0, q1, ..., q31 } */
 
-const uint64 SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC12   = flagBit++;
-const uint64 SPECIFIC13   = flagBit++;
-const uint64 SPECIFIC14   = flagBit++;
-const uint64 SPECIFIC15   = flagBit++;
-const uint64 SPECIFIC16   = flagBit++;
-const uint64 SPECIFIC17   = flagBit++;
+const uint64_t SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC8 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC9 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC10 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC11 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC12   = flagBit++;
+const uint64_t SPECIFIC13   = flagBit++;
+const uint64_t SPECIFIC14   = flagBit++;
+const uint64_t SPECIFIC15   = flagBit++;
+const uint64_t SPECIFIC16   = flagBit++;
+const uint64_t SPECIFIC17   = flagBit++;
 
-const uint64 PTR_O    = flagBit++;
-const uint64 PTR_C    = flagBit++;
+const uint64_t PTR_O    = flagBit++;
+const uint64_t PTR_C    = flagBit++;
 
-const uint64 BRA_O    = flagBit++; /** Test vector is { "{" } */
-const uint64 BRA_C    = flagBit++; /** Test vector is { "}" } */
+const uint64_t BRA_O    = flagBit++; /** Test vector is { "{" } */
+const uint64_t BRA_C    = flagBit++; /** Test vector is { "}" } */
 
-const uint64 PAR_O    = flagBit++; /** Test vector is { "(" } */
-const uint64 PAR_C    = flagBit++; /** Test vector is { ">" } */
+const uint64_t PAR_O    = flagBit++; /** Test vector is { "(" } */
+const uint64_t PAR_C    = flagBit++; /** Test vector is { ">" } */
 
-const uint64 PRE_PTR_O    = flagBit++; /** Test vector is { "[" } or { "pre_ptr(" } */
-const uint64 PRE_PTR_C    = flagBit++; /** Test vector is { "]!" } or { ")" } */
-
-
-//const uint64 POST_PTR  = flagBit++;
+const uint64_t PRE_PTR_O    = flagBit++; /** Test vector is { "[" } or { "pre_ptr(" } */
+const uint64_t PRE_PTR_C    = flagBit++; /** Test vector is { "]!" } or { ")" } */
 
 
-const uint64 T_LSL      = flagBit++; /** Test vector is { "LSL" } */ 
-const uint64 T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
-const uint64 T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
-const uint64 T_SXTX     =  flagBit++; /** Test vector is { "SXTX", "SXT" } */
+//const uint64_t POST_PTR  = flagBit++;
 
-const uint64 IMM_0      =  flagBit++; /** Test vector is { "0" } */
-const uint64 IMM_0_OR_1  =  flagBit++; /** Test vector is { "0", "1" } */
-const uint64 IMM_0_OR_2  =  flagBit++; /** Test vector is { "0", "2" } */
-const uint64 IMM_0_OR_3  =  flagBit++; /** Test vector is { "0", "3" } */
-const uint64 IMM_0_OR_4  =  flagBit++; /** Test vector is { "0", "4" } */
-const uint64 IMM_2       =  flagBit++;
-const uint64 IMM_4       =  flagBit++;
-const uint64 IMM_8       =  flagBit++;
-const uint64 IMM_16      =  flagBit++;
-const uint64 IMM_8_OR_16 =  flagBit++; /** Test vector is { "8", "16" } */
-const uint64 IMM_16_OR_32 =  flagBit++;
-const uint64 IMM_24_OR_48 =  flagBit++;
-const uint64 IMM_32_OR_64 =  flagBit++;
 
-const uint64 VREGB_1D    = flagBit++;
-const uint64 VREGH_1D    = flagBit++;
-const uint64 VREGS_1D    = flagBit++;
-const uint64 VREGD_1D    = flagBit++;
-const uint64 VREGB_2D    = flagBit++;
-const uint64 VREGH_2D    = flagBit++;
-const uint64 VREGS_2D    = flagBit++;
-const uint64 VREGD_2D    = flagBit++;
-const uint64 VREGB_3D    = flagBit++;
-const uint64 VREGH_3D    = flagBit++;
-const uint64 VREGS_3D    = flagBit++;
-const uint64 VREGD_3D    = flagBit++;
-const uint64 VREGB_4D    = flagBit++;
-const uint64 VREGH_4D    = flagBit++;
-const uint64 VREGS_4D    = flagBit++;
-const uint64 VREGD_4D    = flagBit++;
+const uint64_t T_LSL      = flagBit++; /** Test vector is { "LSL" } */
+const uint64_t T_UXTW     = flagBit++; /** Test vector is { "UXTW", "UXT" } */
+const uint64_t T_SXTW     = flagBit++; /** Test vector is { "SXTW", "SXT" } */
+const uint64_t T_SXTX     =  flagBit++; /** Test vector is { "SXTX", "SXT" } */
 
-const uint64 VREG16B_1D  = flagBit++;
-const uint64 VREG8B_1D   = flagBit++;
-const uint64 VREG8H_1D   = flagBit++;
-const uint64 VREG4H_1D   = flagBit++;
-const uint64 VREG4S_1D   = flagBit++;
-const uint64 VREG2S_1D   = flagBit++;
-const uint64 VREG2D_1D   = flagBit++;
-const uint64 VREG1D_1D   = flagBit++;
-const uint64 VREG16B_2D  = flagBit++;
-const uint64 VREG8B_2D   = flagBit++;
-const uint64 VREG8H_2D   = flagBit++;
-const uint64 VREG4H_2D   = flagBit++;
-const uint64 VREG4S_2D   = flagBit++;
-const uint64 VREG2S_2D   = flagBit++;
-const uint64 VREG2D_2D   = flagBit++;
-const uint64 VREG1D_2D   = flagBit++;
-const uint64 VREG16B_3D  = flagBit++;
-const uint64 VREG8B_3D   = flagBit++;
-const uint64 VREG8H_3D   = flagBit++;
-const uint64 VREG4H_3D   = flagBit++;
-const uint64 VREG4S_3D   = flagBit++;
-const uint64 VREG2S_3D   = flagBit++;
-const uint64 VREG2D_3D   = flagBit++;
-const uint64 VREG1D_3D   = flagBit++;
-const uint64 VREG16B_4D  = flagBit++;
-const uint64 VREG8B_4D   = flagBit++;
-const uint64 VREG8H_4D   = flagBit++;
-const uint64 VREG4H_4D   = flagBit++;
-const uint64 VREG4S_4D   = flagBit++;
-const uint64 VREG2S_4D   = flagBit++;
-const uint64 VREG2D_4D   = flagBit++;
-const uint64 VREG1D_4D   = flagBit++;
+const uint64_t IMM_0      =  flagBit++; /** Test vector is { "0" } */
+const uint64_t IMM_0_OR_1  =  flagBit++; /** Test vector is { "0", "1" } */
+const uint64_t IMM_0_OR_2  =  flagBit++; /** Test vector is { "0", "2" } */
+const uint64_t IMM_0_OR_3  =  flagBit++; /** Test vector is { "0", "3" } */
+const uint64_t IMM_0_OR_4  =  flagBit++; /** Test vector is { "0", "4" } */
+const uint64_t IMM_2       =  flagBit++;
+const uint64_t IMM_4       =  flagBit++;
+const uint64_t IMM_8       =  flagBit++;
+const uint64_t IMM_16      =  flagBit++;
+const uint64_t IMM_8_OR_16 =  flagBit++; /** Test vector is { "8", "16" } */
+const uint64_t IMM_16_OR_32 =  flagBit++;
+const uint64_t IMM_24_OR_48 =  flagBit++;
+const uint64_t IMM_32_OR_64 =  flagBit++;
 
-const uint64 VREGB_1D_ELEM    = flagBit++;
-const uint64 VREGH_1D_ELEM    = flagBit++;
-const uint64 VREGS_1D_ELEM    = flagBit++;
-const uint64 VREGD_1D_ELEM    = flagBit++;
-const uint64 VREGB_2D_ELEM    = flagBit++;
-const uint64 VREGH_2D_ELEM    = flagBit++;
-const uint64 VREGS_2D_ELEM    = flagBit++;
-const uint64 VREGD_2D_ELEM    = flagBit++;
-const uint64 VREGB_3D_ELEM    = flagBit++;
-const uint64 VREGH_3D_ELEM    = flagBit++;
-const uint64 VREGS_3D_ELEM    = flagBit++;
-const uint64 VREGD_3D_ELEM    = flagBit++;
-const uint64 VREGB_4D_ELEM    = flagBit++;
-const uint64 VREGH_4D_ELEM    = flagBit++;
-const uint64 VREGS_4D_ELEM    = flagBit++;
-const uint64 VREGD_4D_ELEM    = flagBit++;
+const uint64_t VREGB_1D    = flagBit++;
+const uint64_t VREGH_1D    = flagBit++;
+const uint64_t VREGS_1D    = flagBit++;
+const uint64_t VREGD_1D    = flagBit++;
+const uint64_t VREGB_2D    = flagBit++;
+const uint64_t VREGH_2D    = flagBit++;
+const uint64_t VREGS_2D    = flagBit++;
+const uint64_t VREGD_2D    = flagBit++;
+const uint64_t VREGB_3D    = flagBit++;
+const uint64_t VREGH_3D    = flagBit++;
+const uint64_t VREGS_3D    = flagBit++;
+const uint64_t VREGD_3D    = flagBit++;
+const uint64_t VREGB_4D    = flagBit++;
+const uint64_t VREGH_4D    = flagBit++;
+const uint64_t VREGS_4D    = flagBit++;
+const uint64_t VREGD_4D    = flagBit++;
 
-const uint64 VREG16B_1D_ELEM  = flagBit++;
-const uint64 VREG8B_1D_ELEM   = flagBit++;
-const uint64 VREG8H_1D_ELEM   = flagBit++;
-const uint64 VREG4H_1D_ELEM   = flagBit++;
-const uint64 VREG4S_1D_ELEM   = flagBit++;
-const uint64 VREG2S_1D_ELEM   = flagBit++;
-const uint64 VREG2D_1D_ELEM   = flagBit++;
-const uint64 VREG1D_1D_ELEM   = flagBit++;
-const uint64 VREG16B_2D_ELEM  = flagBit++;
-const uint64 VREG8B_2D_ELEM   = flagBit++;
-const uint64 VREG8H_2D_ELEM   = flagBit++;
-const uint64 VREG4H_2D_ELEM   = flagBit++;
-const uint64 VREG4S_2D_ELEM   = flagBit++;
-const uint64 VREG2S_2D_ELEM   = flagBit++;
-const uint64 VREG2D_2D_ELEM   = flagBit++;
-const uint64 VREG1D_2D_ELEM   = flagBit++;
-const uint64 VREG16B_3D_ELEM  = flagBit++;
-const uint64 VREG8B_3D_ELEM   = flagBit++;
-const uint64 VREG8H_3D_ELEM   = flagBit++;
-const uint64 VREG4H_3D_ELEM   = flagBit++;
-const uint64 VREG4S_3D_ELEM   = flagBit++;
-const uint64 VREG2S_3D_ELEM   = flagBit++;
-const uint64 VREG2D_3D_ELEM   = flagBit++;
-const uint64 VREG1D_3D_ELEM   = flagBit++;
-const uint64 VREG16B_4D_ELEM  = flagBit++;
-const uint64 VREG8B_4D_ELEM   = flagBit++;
-const uint64 VREG8H_4D_ELEM   = flagBit++;
-const uint64 VREG4H_4D_ELEM   = flagBit++;
-const uint64 VREG4S_4D_ELEM   = flagBit++;
-const uint64 VREG2S_4D_ELEM   = flagBit++;
-const uint64 VREG2D_4D_ELEM   = flagBit++;
-const uint64 VREG1D_4D_ELEM   = flagBit++;
+const uint64_t VREG16B_1D  = flagBit++;
+const uint64_t VREG8B_1D   = flagBit++;
+const uint64_t VREG8H_1D   = flagBit++;
+const uint64_t VREG4H_1D   = flagBit++;
+const uint64_t VREG4S_1D   = flagBit++;
+const uint64_t VREG2S_1D   = flagBit++;
+const uint64_t VREG2D_1D   = flagBit++;
+const uint64_t VREG1D_1D   = flagBit++;
+const uint64_t VREG16B_2D  = flagBit++;
+const uint64_t VREG8B_2D   = flagBit++;
+const uint64_t VREG8H_2D   = flagBit++;
+const uint64_t VREG4H_2D   = flagBit++;
+const uint64_t VREG4S_2D   = flagBit++;
+const uint64_t VREG2S_2D   = flagBit++;
+const uint64_t VREG2D_2D   = flagBit++;
+const uint64_t VREG1D_2D   = flagBit++;
+const uint64_t VREG16B_3D  = flagBit++;
+const uint64_t VREG8B_3D   = flagBit++;
+const uint64_t VREG8H_3D   = flagBit++;
+const uint64_t VREG4H_3D   = flagBit++;
+const uint64_t VREG4S_3D   = flagBit++;
+const uint64_t VREG2S_3D   = flagBit++;
+const uint64_t VREG2D_3D   = flagBit++;
+const uint64_t VREG1D_3D   = flagBit++;
+const uint64_t VREG16B_4D  = flagBit++;
+const uint64_t VREG8B_4D   = flagBit++;
+const uint64_t VREG8H_4D   = flagBit++;
+const uint64_t VREG4H_4D   = flagBit++;
+const uint64_t VREG4S_4D   = flagBit++;
+const uint64_t VREG2S_4D   = flagBit++;
+const uint64_t VREG2D_4D   = flagBit++;
+const uint64_t VREG1D_4D   = flagBit++;
 
-const uint64 PRFOP            = flagBit++;
+const uint64_t VREGB_1D_ELEM    = flagBit++;
+const uint64_t VREGH_1D_ELEM    = flagBit++;
+const uint64_t VREGS_1D_ELEM    = flagBit++;
+const uint64_t VREGD_1D_ELEM    = flagBit++;
+const uint64_t VREGB_2D_ELEM    = flagBit++;
+const uint64_t VREGH_2D_ELEM    = flagBit++;
+const uint64_t VREGS_2D_ELEM    = flagBit++;
+const uint64_t VREGD_2D_ELEM    = flagBit++;
+const uint64_t VREGB_3D_ELEM    = flagBit++;
+const uint64_t VREGH_3D_ELEM    = flagBit++;
+const uint64_t VREGS_3D_ELEM    = flagBit++;
+const uint64_t VREGD_3D_ELEM    = flagBit++;
+const uint64_t VREGB_4D_ELEM    = flagBit++;
+const uint64_t VREGH_4D_ELEM    = flagBit++;
+const uint64_t VREGS_4D_ELEM    = flagBit++;
+const uint64_t VREGD_4D_ELEM    = flagBit++;
 
-const uint64 NOPARA = 100000;
+const uint64_t VREG16B_1D_ELEM  = flagBit++;
+const uint64_t VREG8B_1D_ELEM   = flagBit++;
+const uint64_t VREG8H_1D_ELEM   = flagBit++;
+const uint64_t VREG4H_1D_ELEM   = flagBit++;
+const uint64_t VREG4S_1D_ELEM   = flagBit++;
+const uint64_t VREG2S_1D_ELEM   = flagBit++;
+const uint64_t VREG2D_1D_ELEM   = flagBit++;
+const uint64_t VREG1D_1D_ELEM   = flagBit++;
+const uint64_t VREG16B_2D_ELEM  = flagBit++;
+const uint64_t VREG8B_2D_ELEM   = flagBit++;
+const uint64_t VREG8H_2D_ELEM   = flagBit++;
+const uint64_t VREG4H_2D_ELEM   = flagBit++;
+const uint64_t VREG4S_2D_ELEM   = flagBit++;
+const uint64_t VREG2S_2D_ELEM   = flagBit++;
+const uint64_t VREG2D_2D_ELEM   = flagBit++;
+const uint64_t VREG1D_2D_ELEM   = flagBit++;
+const uint64_t VREG16B_3D_ELEM  = flagBit++;
+const uint64_t VREG8B_3D_ELEM   = flagBit++;
+const uint64_t VREG8H_3D_ELEM   = flagBit++;
+const uint64_t VREG4H_3D_ELEM   = flagBit++;
+const uint64_t VREG4S_3D_ELEM   = flagBit++;
+const uint64_t VREG2S_3D_ELEM   = flagBit++;
+const uint64_t VREG2D_3D_ELEM   = flagBit++;
+const uint64_t VREG1D_3D_ELEM   = flagBit++;
+const uint64_t VREG16B_4D_ELEM  = flagBit++;
+const uint64_t VREG8B_4D_ELEM   = flagBit++;
+const uint64_t VREG8H_4D_ELEM   = flagBit++;
+const uint64_t VREG4H_4D_ELEM   = flagBit++;
+const uint64_t VREG4S_4D_ELEM   = flagBit++;
+const uint64_t VREG2S_4D_ELEM   = flagBit++;
+const uint64_t VREG2D_4D_ELEM   = flagBit++;
+const uint64_t VREG1D_4D_ELEM   = flagBit++;
+
+const uint64_t PRFOP            = flagBit++;
+
+const uint64_t NOPARA = 100000;
 
 
 
@@ -246,7 +246,7 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name, 0);			\
   }						\
 
@@ -254,8 +254,8 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }						\
@@ -264,9 +264,9 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -276,10 +276,10 @@ const uint64 NOPARA = 100000;
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -290,11 +290,11 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -306,12 +306,12 @@ const uint64 NOPARA = 100000;
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -324,13 +324,13 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -344,14 +344,14 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -366,15 +366,15 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -390,16 +390,16 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -416,22 +416,22 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -748,7 +748,7 @@ class Test {
     }
   }
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -758,14 +758,14 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
-    return get(op1, (uint64) 0);
+    return get(op1, (uint64_t) 0);
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -873,7 +873,7 @@ class Test {
     }
   }
 
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -882,7 +882,7 @@ class Test {
     return tv_Vectors[type]->size();
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;

--- a/test/make_nm_sve.cpp
+++ b/test/make_nm_sve.cpp
@@ -38,70 +38,70 @@ enum TpPredType {
 };
 
 /** Begin:Really used in this file. */
-uint64 flagBit = 0;
-const uint64 WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 VREG  = 1ULL << flagBit++; /** Test vector is {v0, v1, ..., v31 } */
-const uint64 IMM0BIT   = 1ULL << flagBit++; /** Test vector is {0} */
-const uint64 IMM1BIT   = 1ULL << flagBit++; /** Test vector is {0, 1} */
-const uint64 IMM2BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 3 } */
-const uint64 IMM3BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
-const uint64 IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
-const uint64 IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM3BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 8 } */
-const uint64 IMM4BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 16 } */
-const uint64 IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 32 } */
-const uint64 IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 64 } */
-const uint64 FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
+uint64_t flagBit = 0;
+const uint64_t WREG  = 1ULL << flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = 1ULL << flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t VREG  = 1ULL << flagBit++; /** Test vector is {v0, v1, ..., v31 } */
+const uint64_t IMM0BIT   = 1ULL << flagBit++; /** Test vector is {0} */
+const uint64_t IMM1BIT   = 1ULL << flagBit++; /** Test vector is {0, 1} */
+const uint64_t IMM2BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 3 } */
+const uint64_t IMM3BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
+const uint64_t IMM4BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM8BIT   = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
+const uint64_t IMM12BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = 1ULL << flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM3BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 8 } */
+const uint64_t IMM4BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 16 } */
+const uint64_t IMM5BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 32 } */
+const uint64_t IMM6BIT_N = 1ULL << flagBit++; /** Test vector is {1, 2, .., 64 } */
+const uint64_t FLOAT8BIT = 1ULL << flagBit++; /** Test vector is Table C-2- Floating-point constant values */
 
-const uint64 BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
-const uint64 HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
-const uint64 SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
-const uint64 DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
-const uint64 QREG = 1ULL << flagBit++; /** Test vector is { q0, q1, ..., q31 } */
-const uint64 ZREG = 1ULL << flagBit++; /** Test vector is { z0, z1, ..., z31 } */
+const uint64_t BREG = 1ULL << flagBit++; /** Test vector is { b0, b1, ..., b31 } */
+const uint64_t HREG = 1ULL << flagBit++; /** Test vector is { h0, h1, ..., h31 } */
+const uint64_t SREG = 1ULL << flagBit++; /** Test vector is { s0, s1, ..., s31 } */
+const uint64_t DREG = 1ULL << flagBit++; /** Test vector is { d0, d1, ..., d31 } */
+const uint64_t QREG = 1ULL << flagBit++; /** Test vector is { q0, q1, ..., q31 } */
+const uint64_t ZREG = 1ULL << flagBit++; /** Test vector is { z0, z1, ..., z31 } */
 
-const uint64 SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_4 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_4 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_4 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_4 = 1ULL << flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 ZREG_B   = 1ULL << flagBit++;
-const uint64 ZREG_H   = 1ULL << flagBit++;
-const uint64 ZREG_S   = 1ULL << flagBit++;
-const uint64 ZREG_D   = 1ULL << flagBit++;
-const uint64 ZREG_Q   = 1ULL << flagBit++;
+const uint64_t ZREG_B   = 1ULL << flagBit++;
+const uint64_t ZREG_H   = 1ULL << flagBit++;
+const uint64_t ZREG_S   = 1ULL << flagBit++;
+const uint64_t ZREG_D   = 1ULL << flagBit++;
+const uint64_t ZREG_Q   = 1ULL << flagBit++;
 
-const uint64 ZREG_B_ELEM = 1ULL << flagBit++;
-const uint64 ZREG_H_ELEM = 1ULL << flagBit++;
-const uint64 ZREG_S_ELEM = 1ULL << flagBit++;
-const uint64 ZREG_D_ELEM = 1ULL << flagBit++;
+const uint64_t ZREG_B_ELEM = 1ULL << flagBit++;
+const uint64_t ZREG_H_ELEM = 1ULL << flagBit++;
+const uint64_t ZREG_S_ELEM = 1ULL << flagBit++;
+const uint64_t ZREG_D_ELEM = 1ULL << flagBit++;
 
-const uint64 PREG_B   = 1ULL << flagBit++;
-const uint64 PREG_H   = 1ULL << flagBit++;
-const uint64 PREG_S   = 1ULL << flagBit++;
-const uint64 PREG_D   = 1ULL << flagBit++;
+const uint64_t PREG_B   = 1ULL << flagBit++;
+const uint64_t PREG_H   = 1ULL << flagBit++;
+const uint64_t PREG_S   = 1ULL << flagBit++;
+const uint64_t PREG_D   = 1ULL << flagBit++;
 
-const uint64 PG_M     = 1ULL << flagBit++;
-const uint64 PG_Z     = 1ULL << flagBit++;
-const uint64 PG       = 1ULL << flagBit++;
-const uint64 PG_ZM    = PG_M | PG_Z;
+const uint64_t PG_M     = 1ULL << flagBit++;
+const uint64_t PG_Z     = 1ULL << flagBit++;
+const uint64_t PG       = 1ULL << flagBit++;
+const uint64_t PG_ZM    = PG_M | PG_Z;
 
-const uint64 PATTERN  = 1ULL << flagBit++;
-const uint64 SFLOAT8BIT = 1ULL << flagBit++;
+const uint64_t PATTERN  = 1ULL << flagBit++;
+const uint64_t SFLOAT8BIT = 1ULL << flagBit++;
 
-const uint64 NOPARA = 1ULL << (bitEnd - 1);
+const uint64_t NOPARA = 1ULL << (bitEnd - 1);
 
 
 
@@ -116,7 +116,7 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
+    std::vector<uint64_t> op1(op_1);		\
     put(nemonic, op1, #name);					\
   }						\
 
@@ -124,8 +124,8 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
   }						\
@@ -134,9 +134,9 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -146,10 +146,10 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const			\
   {						\
     std::vector<std::string> nemonic(nm);	\
-    std::vector<uint64> op1(op_1);		\
-    std::vector<uint64> op2(op_2);		\
-    std::vector<uint64> op3(op_3);		\
-    std::vector<uint64> op4(op_4);		\
+    std::vector<uint64_t> op1(op_1);		\
+    std::vector<uint64_t> op2(op_2);		\
+    std::vector<uint64_t> op3(op_3);		\
+    std::vector<uint64_t> op4(op_4);		\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -160,11 +160,11 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name);					\
     put(nemonic, op2, #name);					\
     put(nemonic, op3, #name);					\
@@ -176,12 +176,12 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name);						\
     put(nemonic, op2, #name);						\
     put(nemonic, op3, #name);						\
@@ -194,13 +194,13 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name);							\
     put(nemonic, op2, #name);							\
     put(nemonic, op3, #name);							\
@@ -214,14 +214,14 @@ const uint64 NOPARA = 1ULL << (bitEnd - 1);
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name);							\
     put(nemonic, op2, #name);							\
     put(nemonic, op3, #name);							\
@@ -413,7 +413,7 @@ class Test {
     }
   }
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name) const
   {
     std::cout << "//" << name << std::endl; /** For easy debug */
     
@@ -423,8 +423,8 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
     for (int i = 0; i < bitEnd; i++) {
       if (op1 & (1ULL << i)) {
@@ -438,7 +438,7 @@ class Test {
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -519,7 +519,7 @@ class Test {
     */
     for(i = 0; i < num_ops; i++) {
       for(j = 0; j < bitEnd; j++) {
-	uint64 bitpos = 1ULL << j;
+	uint64_t bitpos = 1ULL << j;
 	
 	if(!(ops[i] & bitpos)) continue;
 
@@ -559,7 +559,7 @@ class Test {
     }
   }
     
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -576,7 +576,7 @@ class Test {
     return 0;
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -738,8 +738,8 @@ public:
 
   
   void setRotatedOnes(std::vector<std::string>& tv, std::vector<std::string>& jtv, int dataSize) {
-    uint64 mask = 0;
-    std::vector<uint64> base = { 1, 3, 7, 15 };
+    uint64_t mask = 0;
+    std::vector<uint64_t> base = { 1, 3, 7, 15 };
 
     tv.clear();
     jtv.clear();
@@ -758,8 +758,8 @@ public:
       
     
     for(int len=0; len< dataSize/4; len++) {
-      for(const uint64 i : base) {
-	uint64 hoge = i;
+      for(const uint64_t i : base) {
+	uint64_t hoge = i;
 
 	for(int j=1; j<=len; j++) {
 	  hoge = (hoge << 4) + 0xf;

--- a/test/make_nm_sve_addr.cpp
+++ b/test/make_nm_sve_addr.cpp
@@ -37,83 +37,83 @@ enum TpPredType {
 		 TP_NONE /** No indication. */
 };
 
-uint64 flagBit = 0;
-const uint64 WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
-const uint64 XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
-const uint64 VREG  = flagBit++; /** Test vector is {v0, v1, ..., v31 } */
-const uint64 WSP   = flagBit++; /** Test vector is { wsp } */
-const uint64 XSP   = flagBit++; /** Test vector is { sp } */
-const uint64 WNSP  = flagBit++;
-const uint64 XNSP  = flagBit++;
-const uint64 IMM0BIT   = flagBit++; /** Test vector is {0} */
-const uint64 IMM1BIT   = flagBit++; /** Test vector is {0, 1} */
-const uint64 IMM2BIT   = flagBit++; /** Test vector is {0, 1, 2, 3 } */
-const uint64 IMM3BIT   = flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
-const uint64 IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
-const uint64 IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
-const uint64 IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
-const uint64 IMM8BIT   = flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
-const uint64 IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
-const uint64 IMM13BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
-const uint64 IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
-const uint64 IMM3BIT_N = flagBit++; /** Test vector is {1, 2, .., 8 } */
-const uint64 IMM4BIT_N = flagBit++; /** Test vector is {1, 2, .., 16 } */
-const uint64 IMM5BIT_N = flagBit++; /** Test vector is {1, 2, .., 32 } */
-const uint64 IMM6BIT_N = flagBit++; /** Test vector is {1, 2, .., 64 } */
-const uint64 FLOAT8BIT = flagBit++; /** Test vector is Table C-2- Floating-point constant values */
+uint64_t flagBit = 0;
+const uint64_t WREG  = flagBit++; /** Test vector is {w0, w1, ..., w30 } */
+const uint64_t XREG  = flagBit++; /** Test vector is {x0, x1, ..., x30 } */
+const uint64_t VREG  = flagBit++; /** Test vector is {v0, v1, ..., v31 } */
+const uint64_t WSP   = flagBit++; /** Test vector is { wsp } */
+const uint64_t XSP   = flagBit++; /** Test vector is { sp } */
+const uint64_t WNSP  = flagBit++;
+const uint64_t XNSP  = flagBit++;
+const uint64_t IMM0BIT   = flagBit++; /** Test vector is {0} */
+const uint64_t IMM1BIT   = flagBit++; /** Test vector is {0, 1} */
+const uint64_t IMM2BIT   = flagBit++; /** Test vector is {0, 1, 2, 3 } */
+const uint64_t IMM3BIT   = flagBit++; /** Test vector is {0, 1, 2, 4, 7 } */
+const uint64_t IMM4BIT   = flagBit++; /** Test vector is {0, 1, ..., 8, 15 } */
+const uint64_t IMM5BIT   = flagBit++; /** Test vector is {0, 1, ..., 16, 31 } */
+const uint64_t IMM6BIT   = flagBit++; /** Test vector is {0, 1, ..., 32, 63 } */
+const uint64_t IMM8BIT   = flagBit++; /** Test vector is {0, 1, ..., 128, 255 } */
+const uint64_t IMM12BIT  = flagBit++; /** Test vector is {0, 1, ..., 2048, 4095 } */
+const uint64_t IMM13BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 8191 } */
+const uint64_t IMM16BIT  = flagBit++; /** Test vector is {0, 1, ..., 4096, 1<<13, 1<<14, 1<<15, 1<<16-1 } */
+const uint64_t IMM3BIT_N = flagBit++; /** Test vector is {1, 2, .., 8 } */
+const uint64_t IMM4BIT_N = flagBit++; /** Test vector is {1, 2, .., 16 } */
+const uint64_t IMM5BIT_N = flagBit++; /** Test vector is {1, 2, .., 32 } */
+const uint64_t IMM6BIT_N = flagBit++; /** Test vector is {1, 2, .., 64 } */
+const uint64_t FLOAT8BIT = flagBit++; /** Test vector is Table C-2- Floating-point constant values */
 
-const uint64 ZREG = flagBit++; /** Test vector is { z0, z1, ..., z31 } */
-const uint64 SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC32_5 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC64_5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t ZREG = flagBit++; /** Test vector is { z0, z1, ..., z31 } */
+const uint64_t SPECIFIC32 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC32_5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC64_5 = flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
-const uint64 SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC0 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC1 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC2 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC3 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC4 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC5 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC6 = flagBit++; /** Test vector is generated on the fly. */
+const uint64_t SPECIFIC7 = flagBit++; /** Test vector is generated on the fly. */
 
-const uint64 ZREG_B   = flagBit++;
-const uint64 ZREG_H   = flagBit++;
-const uint64 ZREG_S   = flagBit++;
-const uint64 ZREG_D   = flagBit++;
-const uint64 ZREG_Q   = flagBit++;
+const uint64_t ZREG_B   = flagBit++;
+const uint64_t ZREG_H   = flagBit++;
+const uint64_t ZREG_S   = flagBit++;
+const uint64_t ZREG_D   = flagBit++;
+const uint64_t ZREG_Q   = flagBit++;
 
-const uint64 PREG_B   = flagBit++;
-const uint64 PREG_H   = flagBit++;
-const uint64 PREG_S   = flagBit++;
-const uint64 PREG_D   = flagBit++;
+const uint64_t PREG_B   = flagBit++;
+const uint64_t PREG_H   = flagBit++;
+const uint64_t PREG_S   = flagBit++;
+const uint64_t PREG_D   = flagBit++;
 
-const uint64 PG_M     = flagBit++;
-const uint64 PG_Z     = flagBit++;
-const uint64 PG       = flagBit++;
-const uint64 PG_ZM    = flagBit++;
+const uint64_t PG_M     = flagBit++;
+const uint64_t PG_Z     = flagBit++;
+const uint64_t PG       = flagBit++;
+const uint64_t PG_ZM    = flagBit++;
 
-const uint64 PTR_O    = flagBit++;
-const uint64 PTR_C    = flagBit++;
+const uint64_t PTR_O    = flagBit++;
+const uint64_t PTR_C    = flagBit++;
 
-const uint64 BRA_O    = flagBit++; /** Test vector is { "{" } */
-const uint64 BRA_C    = flagBit++; /** Test vector is { "}" } */
+const uint64_t BRA_O    = flagBit++; /** Test vector is { "{" } */
+const uint64_t BRA_C    = flagBit++; /** Test vector is { "}" } */
 
-const uint64 XTW      = flagBit++;
-const uint64 PRFOP    = flagBit++;
-const uint64 PRFOP_SVE= flagBit++;
-const uint64 MULVL    = flagBit++;
+const uint64_t XTW      = flagBit++;
+const uint64_t PRFOP    = flagBit++;
+const uint64_t PRFOP_SVE= flagBit++;
+const uint64_t MULVL    = flagBit++;
 
 
-const uint64 NOPARA = 100000;
+const uint64_t NOPARA = 100000;
 
 
 #define PUT0(name, nm)					\
@@ -127,7 +127,7 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
+    std::vector<uint64_t> op1(op_1);			\
     put(nemonic, op1, #name, 0);			\
   }							\
   
@@ -135,8 +135,8 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
   }							\
@@ -145,9 +145,9 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
     put(nemonic, op1, #name, 0);			\
     put(nemonic, op2, #name, 1);				\
     put(nemonic, op3, #name, 2);					\
@@ -157,10 +157,10 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -171,11 +171,11 @@ const uint64 NOPARA = 100000;
   void put##name() const				\
   {							\
     std::vector<std::string> nemonic(nm);		\
-    std::vector<uint64> op1(op_1);			\
-    std::vector<uint64> op2(op_2);			\
-    std::vector<uint64> op3(op_3);			\
-    std::vector<uint64> op4(op_4);			\
-    std::vector<uint64> op5(op_5);			\
+    std::vector<uint64_t> op1(op_1);			\
+    std::vector<uint64_t> op2(op_2);			\
+    std::vector<uint64_t> op3(op_3);			\
+    std::vector<uint64_t> op4(op_4);			\
+    std::vector<uint64_t> op5(op_5);			\
     put(nemonic, op1, #name, 0);				\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);						\
@@ -187,12 +187,12 @@ const uint64 NOPARA = 100000;
   void put##name() const					\
   {								\
     std::vector<std::string> nemonic(nm);			\
-    std::vector<uint64> op1(op_1);				\
-    std::vector<uint64> op2(op_2);				\
-    std::vector<uint64> op3(op_3);				\
-    std::vector<uint64> op4(op_4);				\
-    std::vector<uint64> op5(op_5);				\
-    std::vector<uint64> op6(op_6);				\
+    std::vector<uint64_t> op1(op_1);				\
+    std::vector<uint64_t> op2(op_2);				\
+    std::vector<uint64_t> op3(op_3);				\
+    std::vector<uint64_t> op4(op_4);				\
+    std::vector<uint64_t> op5(op_5);				\
+    std::vector<uint64_t> op6(op_6);				\
     put(nemonic, op1, #name, 0);					\
     put(nemonic, op2, #name, 1);					\
     put(nemonic, op3, #name, 2);					\
@@ -205,13 +205,13 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -225,14 +225,14 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -247,15 +247,15 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -271,16 +271,16 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -297,22 +297,22 @@ const uint64 NOPARA = 100000;
   void put##name() const						\
   {									\
     std::vector<std::string> nemonic(nm);				\
-    std::vector<uint64> op1(op_1);					\
-    std::vector<uint64> op2(op_2);					\
-    std::vector<uint64> op3(op_3);					\
-    std::vector<uint64> op4(op_4);					\
-    std::vector<uint64> op5(op_5);					\
-    std::vector<uint64> op6(op_6);					\
-    std::vector<uint64> op7(op_7);					\
-    std::vector<uint64> op8(op_8);					\
-    std::vector<uint64> op9(op_9);					\
-    std::vector<uint64> op10(op_10);					\
-    std::vector<uint64> op11(op_11);					\
-    std::vector<uint64> op12(op_12);					\
-    std::vector<uint64> op13(op_13);					\
-    std::vector<uint64> op14(op_14);					\
-    std::vector<uint64> op15(op_15);					\
-    std::vector<uint64> op16(op_16);					\
+    std::vector<uint64_t> op1(op_1);					\
+    std::vector<uint64_t> op2(op_2);					\
+    std::vector<uint64_t> op3(op_3);					\
+    std::vector<uint64_t> op4(op_4);					\
+    std::vector<uint64_t> op5(op_5);					\
+    std::vector<uint64_t> op6(op_6);					\
+    std::vector<uint64_t> op7(op_7);					\
+    std::vector<uint64_t> op8(op_8);					\
+    std::vector<uint64_t> op9(op_9);					\
+    std::vector<uint64_t> op10(op_10);					\
+    std::vector<uint64_t> op11(op_11);					\
+    std::vector<uint64_t> op12(op_12);					\
+    std::vector<uint64_t> op13(op_13);					\
+    std::vector<uint64_t> op14(op_14);					\
+    std::vector<uint64_t> op15(op_15);					\
+    std::vector<uint64_t> op16(op_16);					\
     put(nemonic, op1, #name, 0);						\
     put(nemonic, op2, #name, 1);						\
     put(nemonic, op3, #name, 2);						\
@@ -543,7 +543,7 @@ class Test {
 	}
       }
 
-  void put(std::vector<std::string> &n, std::vector<uint64> &opSet, std::string name, int serial=0) const
+  void put(std::vector<std::string> &n, std::vector<uint64_t> &opSet, std::string name, int serial=0) const
   {
     std::cout << "//" << name << ":" << serial << std::endl; /** For easy debug */
     
@@ -553,14 +553,14 @@ class Test {
     }
   }
 
-  //  char* getBaseStr(uint64 op1)
-  const char* getBaseStr(uint64 op1) const
+  //  char* getBaseStr(uint64_t op1)
+  const char* getBaseStr(uint64_t op1) const
   {
-    return get(op1, (uint64) 0);
+    return get(op1, (uint64_t) 0);
   }
   
   /** check all op1, op2, op3, op4, op5, op6, op7, op8 */
-  void put(const char *nm, std::vector<uint64>& ops) const
+  void put(const char *nm, std::vector<uint64_t>& ops) const
   {
     std::vector<std::string> strBase;
     std::string hoge;
@@ -669,7 +669,7 @@ class Test {
     }
   }
 
-  uint64 getNum(uint64 type) const
+  uint64_t getNum(uint64_t type) const
   {
     if(type==NOPARA) {
       return 0;
@@ -678,7 +678,7 @@ class Test {
     return tv_Vectors[type]->size();
   }
 
-  const char *get(uint64 type, uint64 index) const
+  const char *get(uint64_t type, uint64_t index) const
   {
     if(type==NOPARA) {
       std::cerr << std::endl << __FILE__ << ":" << __LINE__ << ", Something wrong. type=" << type << " index=" << index << std::endl;
@@ -853,8 +853,8 @@ public:
 
   
   void setRotatedOnes(std::vector<std::string>& tv, std::vector<std::string>& jtv, int dataSize) {
-    uint64 mask = 0;
-    std::vector<uint64> base = { 1, 3, 7, 15 };
+    uint64_t mask = 0;
+    std::vector<uint64_t> base = { 1, 3, 7, 15 };
 
     tv.clear();
     jtv.clear();
@@ -873,8 +873,8 @@ public:
       
     
     for(int len=0; len< dataSize/4; len++) {
-      for(const uint64 i : base) {
-	uint64 hoge = i;
+      for(const uint64_t i : base) {
+	uint64_t hoge = i;
 
 	for(int j=1; j<=len; j++) {
 	  hoge = (hoge << 4) + 0xf;

--- a/test/meta_mnemonic.cpp
+++ b/test/meta_mnemonic.cpp
@@ -133,7 +133,7 @@ int main() {
     std::numeric_limits<int64_t>::max()
   };
   
-  std::vector<uint64_t> v_uint64 = {
+  std::vector<uint64_t> v_uint64_t = {
     0,
     1, 2046, 2047, 2048, 2049,
     std::numeric_limits<uint64_t>::max() - 1,
@@ -143,12 +143,12 @@ int main() {
   test_add(v_int32);
   test_add(v_uint32);
   test_add(v_int64);
-  test_add(v_uint64);
+  test_add(v_uint64_t);
 
   test_sub(v_int32);
   test_sub(v_uint32);
   test_sub(v_int64);
-  test_sub(v_uint64);
+  test_sub(v_uint64_t);
 
 
   return 0;

--- a/xbyak_aarch64/xbyak_aarch64.h
+++ b/xbyak_aarch64/xbyak_aarch64.h
@@ -54,21 +54,6 @@
 #endif
 
 namespace Xbyak {
-
-#ifndef MIE_INTEGER_TYPE_DEFINED
-#define MIE_INTEGER_TYPE_DEFINED
-#ifdef _MSC_VER
-typedef unsigned __int64 uint64;
-typedef __int64 sint64;
-#else
-typedef uint64_t uint64;
-typedef int64_t sint64;
-#endif
-typedef unsigned int uint32;
-typedef unsigned short uint16;
-typedef unsigned char uint8;
-#endif
-
 #include "xbyak_aarch64_gen.h"
 }
 

--- a/xbyak_aarch64/xbyak_aarch64_reg.h
+++ b/xbyak_aarch64/xbyak_aarch64_reg.h
@@ -496,10 +496,10 @@ struct Opmask : public Reg {
 class Label;
 
 struct RegRip {
-  sint64 disp_;
+  int64_t disp_;
   const Label *label_;
   bool isAddr_;
-  explicit RegRip(sint64 disp = 0, const Label *label = 0, bool isAddr = false)
+  explicit RegRip(int64_t disp = 0, const Label *label = 0, bool isAddr = false)
       : disp_(disp), label_(label), isAddr_(isAddr) {}
   friend const RegRip operator+(const RegRip &r, int disp) {
     return RegRip(r.disp_ + disp, r.label_, r.isAddr_);
@@ -507,10 +507,10 @@ struct RegRip {
   friend const RegRip operator-(const RegRip &r, int disp) {
     return RegRip(r.disp_ - disp, r.label_, r.isAddr_);
   }
-  friend const RegRip operator+(const RegRip &r, sint64 disp) {
+  friend const RegRip operator+(const RegRip &r, int64_t disp) {
     return RegRip(r.disp_ + disp, r.label_, r.isAddr_);
   }
-  friend const RegRip operator-(const RegRip &r, sint64 disp) {
+  friend const RegRip operator-(const RegRip &r, int64_t disp) {
     return RegRip(r.disp_ - disp, r.label_, r.isAddr_);
   }
   friend const RegRip operator+(const RegRip &r, const Label &label) {
@@ -519,7 +519,7 @@ struct RegRip {
   }
   friend const RegRip operator+(const RegRip &r, const void *addr) {
     if (r.label_ || r.isAddr_) throw Error(ERR_BAD_ADDRESSING);
-    return RegRip(r.disp_ + (sint64)addr, 0, true);
+    return RegRip(r.disp_ + (int64_t)addr, 0, true);
   }
 };
 


### PR DESCRIPTION
`uint64` is defined for a very old compiler in xbyak, so I think that it is better to use standard type `uint64_t` instead of it now.