### PR TITLE
Remove obj macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Then execute the following commands.
 ```
 cd xbyak_aarch64/sample
 aarch64-linux-gnu-g++ add.cpp
-env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu ./a.out
+env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu qemu-aarch64 ./a.out
 ```
 
 ## How to use Xbyak_aarch64
@@ -79,7 +79,6 @@ and 2) call the function. This example outputs "7" to STDOUT.
 
 
 ```
-#define XBYAK_AARCH64_OBJ
 #include <xbyak_aarch64/xbyak_aarch64.h>
 using namespace Xbyak;
 class Generator : public CodeGenerator {

--- a/README.md
+++ b/README.md
@@ -65,9 +65,8 @@ The following dpkgs are required.
 Then execute the following commands.
 ```
 cd xbyak_aarch64/sample
-export LD_LIBRARY_PATH=/usr/aarch64-linux-gnu/lib
 aarch64-linux-gnu-g++ add.cpp
-qemu-aarch64 ./a.out
+env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu ./a.out
 ```
 
 ## How to use Xbyak_aarch64

--- a/sample/add.cpp
+++ b/sample/add.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-#define XBYAK_AARCH64_OBJ
 #include "../xbyak_aarch64/xbyak_aarch64.h"
 using namespace Xbyak;
 class Generator : public CodeGenerator {

--- a/sample/label.cpp
+++ b/sample/label.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-#define XBYAK_AARCH64_OBJ
 #include "../xbyak_aarch64/xbyak_aarch64.h"
 using namespace Xbyak;
 class Generator : public CodeGenerator {

--- a/test/meta_mnemonic.cpp
+++ b/test/meta_mnemonic.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  *******************************************************************************/
 #define TEST_NUM 1
-#define XBYAK_AARCH64_OBJ
 
 #include <cstring>
 #include "../xbyak_aarch64/xbyak_aarch64.h"

--- a/test/test_nm.sh
+++ b/test/test_nm.sh
@@ -38,7 +38,7 @@ dumpNG () {
 }    
 
 # Make binary
-${GPP} -g -std=c++11 -fomit-frame-pointer -Wall -fno-operator-names -I../xbyak_aarch64 -I./ -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -DXBYAK_AARCH64_OBJ -o ${TEST_FILE} ${TEST_FILE}.cpp
+${GPP} -g -std=c++11 -fomit-frame-pointer -Wall -fno-operator-names -I../xbyak_aarch64 -I./ -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -o ${TEST_FILE} ${TEST_FILE}.cpp
 
 if [ $? != 0 ] ; then
     dumpNG "Compiling binary for generating test source file."
@@ -79,7 +79,7 @@ if [ $? != 0 ] ;then
     dumpNG "Generating source file using xbyak"
     exit 1
 fi
-${GPP} -g -I../xbyak_aarch64 -DXBYAK_TEST -DXBYAK_AARCH64_OBJ -o nm_frame nm_frame.cpp 
+${GPP} -g -I../xbyak_aarch64 -DXBYAK_TEST -o nm_frame nm_frame.cpp
 if [ $? != 0 ] ;then
     dumpNG "Compiling source file using xbyak"
     exit 1

--- a/utility/make_reg_class.py
+++ b/utility/make_reg_class.py
@@ -105,7 +105,7 @@ def DEF_VREG_LIST(size, bits, lane):
   return """class VReg%(lane)s%(size)sList : public VRegList {
  public:
   VReg%(lane)s%(size)sList(const VReg%(lane)s%(size)s &s);
-  explicit VReg%(lane)s%(size)sList(const VRegVec &s, const VRegVec &e)
+  VReg%(lane)s%(size)sList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VReg%(size)sElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -113,10 +113,17 @@ def DEF_VREG_LIST(size, bits, lane):
   }
 };""" % {'size':size, 'bits':bits, 'lane':lane}
 
-for (size, bits, lane) in [
+def DEF_VREG_LIST_CSTR(size, bits, lane):
+  return "inline VReg%(lane)s%(size)sList::VReg%(lane)s%(size)sList(const VReg%(lane)s%(size)s &s) : VRegList(s, s) {}" % {'size':size, 'bits':bits, 'lane':lane}
+
+tblList = [
   (B, 8, 4), (B, 8, 8), (B, 8, 16), (H, 16, 2),
   (H, 16, 4), (H, 16, 8), (S, 32, 2), (S, 32, 4),
   (D, 64, 1), (D, 64, 2), (Q, 128, 1)
-]:
+]
+for (size, bits, lane) in tblList:
   print(DEF_VREG_LIST(size, bits, lane))
+print()
+for (size, bits, lane) in tblList:
+  print(DEF_VREG_LIST_CSTR(size, bits, lane))
 print()

--- a/xbyak_aarch64/xbyak_aarch64_adr.h
+++ b/xbyak_aarch64/xbyak_aarch64_adr.h
@@ -438,76 +438,74 @@ AdrVec ptr(const ZRegS &zn, const ZRegS &zm, ShMod mod = NONE, uint32_t sh = 0);
 AdrVec ptr(const ZRegD &zn, const ZRegD &zm, ShMod mod = NONE, uint32_t sh = 0);
 AdrVecU ptr(const ZRegD &zn, const ZRegD &zm, ExtMod mod, uint32_t sh = 0);
 
-#ifdef XBYAK_AARCH64_OBJ
-AdrNoOfs ptr(const XReg &xn) { return AdrNoOfs(xn); }
+inline AdrNoOfs ptr(const XReg &xn) { return AdrNoOfs(xn); }
 
-AdrImm ptr(const XReg &xn, int32_t imm) { return AdrImm(xn, imm); }
+inline AdrImm ptr(const XReg &xn, int32_t imm) { return AdrImm(xn, imm); }
 
-AdrUimm ptr(const XReg &xn, uint32_t uimm) { return AdrUimm(xn, uimm); }
+inline AdrUimm ptr(const XReg &xn, uint32_t uimm) { return AdrUimm(xn, uimm); }
 
-AdrReg ptr(const XReg &xn, const XReg &xm) { return AdrReg(xn, xm); }
+inline AdrReg ptr(const XReg &xn, const XReg &xm) { return AdrReg(xn, xm); }
 
-AdrReg ptr(const XReg &xn, const XReg &xm, ShMod mod, uint32_t sh) {
+inline AdrReg ptr(const XReg &xn, const XReg &xm, ShMod mod, uint32_t sh) {
   return AdrReg(xn, xm, mod, sh);
 }
 
-AdrReg ptr(const XReg &xn, const XReg &xm, ShMod mod) {
+inline AdrReg ptr(const XReg &xn, const XReg &xm, ShMod mod) {
   return AdrReg(xn, xm, mod);
 }
 
-AdrExt ptr(const XReg &xn, const RReg &rm, ExtMod mod, uint32_t sh) {
+inline AdrExt ptr(const XReg &xn, const RReg &rm, ExtMod mod, uint32_t sh) {
   return AdrExt(xn, rm, mod, sh);
 }
 
-AdrExt ptr(const XReg &xn, const RReg &rm, ExtMod mod) {
+inline AdrExt ptr(const XReg &xn, const RReg &rm, ExtMod mod) {
   return AdrExt(xn, rm, mod);
 }
 
-AdrPreImm pre_ptr(const XReg &xn, int32_t imm) { return AdrPreImm(xn, imm); }
+inline AdrPreImm pre_ptr(const XReg &xn, int32_t imm) { return AdrPreImm(xn, imm); }
 
-AdrPostImm post_ptr(const XReg &xn, int32_t imm) { return AdrPostImm(xn, imm); }
+inline AdrPostImm post_ptr(const XReg &xn, int32_t imm) { return AdrPostImm(xn, imm); }
 
-AdrPostReg post_ptr(const XReg &xn, XReg xm) { return AdrPostReg(xn, xm); }
+inline AdrPostReg post_ptr(const XReg &xn, XReg xm) { return AdrPostReg(xn, xm); }
 
-AdrScImm ptr(const XReg &xn, int32_t simm, ExtMod mod) {
+inline AdrScImm ptr(const XReg &xn, int32_t simm, ExtMod mod) {
   return AdrScImm(xn, simm, mod);
 }
 
-AdrSc64U ptr(const XReg &xn, const ZRegD &zm) { return AdrSc64U(xn, zm); }
+inline AdrSc64U ptr(const XReg &xn, const ZRegD &zm) { return AdrSc64U(xn, zm); }
 
-AdrSc64S ptr(const XReg &xn, const ZRegD &zm, ShMod mod, uint32_t sh) {
+inline AdrSc64S ptr(const XReg &xn, const ZRegD &zm, ShMod mod, uint32_t sh) {
   return AdrSc64S(xn, zm, mod, sh);
 }
 
-AdrSc32U ptr(const XReg &xn, const ZRegS &zm, ExtMod mod) {
+inline AdrSc32U ptr(const XReg &xn, const ZRegS &zm, ExtMod mod) {
   return AdrSc32U(xn, zm, mod);
 }
 
-AdrSc32S ptr(const XReg &xn, const ZRegS &zm, ExtMod mod, uint32_t sh) {
+inline AdrSc32S ptr(const XReg &xn, const ZRegS &zm, ExtMod mod, uint32_t sh) {
   return AdrSc32S(xn, zm, mod, sh);
 }
 
-AdrSc32UU ptr(const XReg &xn, const ZRegD &zm, ExtMod mod) {
+inline AdrSc32UU ptr(const XReg &xn, const ZRegD &zm, ExtMod mod) {
   return AdrSc32UU(xn, zm, mod);
 }
 
-AdrSc32US ptr(const XReg &xn, const ZRegD &zm, ExtMod mod, uint32_t sh) {
+inline AdrSc32US ptr(const XReg &xn, const ZRegD &zm, ExtMod mod, uint32_t sh) {
   return AdrSc32US(xn, zm, mod, sh);
 }
 
-AdrVecImm64 ptr(const ZRegD &zn, uint32_t imm) { return AdrVecImm64(zn, imm); }
+inline AdrVecImm64 ptr(const ZRegD &zn, uint32_t imm) { return AdrVecImm64(zn, imm); }
 
-AdrVecImm32 ptr(const ZRegS &zn, uint32_t imm) { return AdrVecImm32(zn, imm); }
+inline AdrVecImm32 ptr(const ZRegS &zn, uint32_t imm) { return AdrVecImm32(zn, imm); }
 
-AdrVec ptr(const ZRegS &zn, const ZRegS &zm, ShMod mod, uint32_t sh) {
+inline AdrVec ptr(const ZRegS &zn, const ZRegS &zm, ShMod mod, uint32_t sh) {
   return AdrVec(zn, zm, mod, sh);
 }
 
-AdrVec ptr(const ZRegD &zn, const ZRegD &zm, ShMod mod, uint32_t sh) {
+inline AdrVec ptr(const ZRegD &zn, const ZRegD &zm, ShMod mod, uint32_t sh) {
   return AdrVec(zn, zm, mod, sh);
 }
 
-AdrVecU ptr(const ZRegD &zn, const ZRegD &zm, ExtMod mod, uint32_t sh) {
+inline AdrVecU ptr(const ZRegD &zn, const ZRegD &zm, ExtMod mod, uint32_t sh) {
   return AdrVecU(zn, zm, mod, sh);
 }
-#endif  // #ifdef XBYAK_AARCH64_OBJ

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -51,13 +51,13 @@ class Error : public std::exception {
   int err_;
   std::string msg_;
   std::string opt_msg_;
-  static const std::initializer_list<const char *> errTbl;
 
  public:
-  explicit Error(int err, std::string opt_msg = "")
+  explicit Error(int err, const std::string& opt_msg = "")
       : err_(err), msg_(""), opt_msg_(opt_msg) {
     if (err_ > 0) {
       fprintf(stderr, "bad err=%d in Xbyak::Error\n", err_);
+      const std::initializer_list<const char *>& errTbl = getErrTbl();
       assert((size_t)err_ < errTbl.size());
       msg_ = "";
       msg_ += *(errTbl.begin() + err_);
@@ -68,36 +68,38 @@ class Error : public std::exception {
   }
   operator int() const { return err_; }
   const char *what() const throw() { return msg_.c_str(); }
+ private:
+  static const std::initializer_list<const char *>& getErrTbl() {
+    static const std::initializer_list<const char *> tbl = {
+      "none",
+      "code is too big",
+      "label is redefined",
+      "label is too far",
+      "label is not found",
+      "bad parameter",
+      "can't protect",
+      "offset is too big",
+      "can't alloc",
+      "label is not set by L()",
+      "label is already set by L()",
+      "internal error",
+      "illegal register index (can not encoding register index)",
+      "illegal register element index (can not encoding element index)",
+      "illegal predicate register type",
+      "illegal immediate parameter (range error)",
+      "illegal immediate parameter (unavailable value error)",
+      "illegal immediate parameter (condition error)",
+      "illegal shift-mode paramater",
+      "illegal extend-mode parameter",
+      "illegal condition parameter",
+      "illegal barrier option",
+      "illegal const parameter (range error)",
+      "illegal const parameter (unavailable error)",
+      "illegal const parameter (condition error)",
+    };
+    return tbl;
+  };
 };
-
-#ifdef XBYAK_AARCH64_OBJ
-const std::initializer_list<const char *> Error::errTbl = {
-    "none",
-    "code is too big",
-    "label is redefined",
-    "label is too far",
-    "label is not found",
-    "bad parameter",
-    "can't protect",
-    "offset is too big",
-    "can't alloc",
-    "label is not set by L()",
-    "label is already set by L()",
-    "internal error",
-    "illegal register index (can not encoding register index)",
-    "illegal register element index (can not encoding element index)",
-    "illegal predicate register type",
-    "illegal immediate parameter (range error)",
-    "illegal immediate parameter (unavailable value error)",
-    "illegal immediate parameter (condition error)",
-    "illegal shift-mode paramater",
-    "illegal extend-mode parameter",
-    "illegal condition parameter",
-    "illegal barrier option",
-    "illegal const parameter (range error)",
-    "illegal const parameter (unavailable error)",
-    "illegal const parameter (condition error)"};
-#endif  // #ifdef XBYAK_AARCH64_OBJ
 
 inline const char *ConvertErrorToString(const Error &err) { return err.what(); }
 

--- a/xbyak_aarch64/xbyak_aarch64_reg.h
+++ b/xbyak_aarch64/xbyak_aarch64_reg.h
@@ -245,7 +245,7 @@ class VRegQElem : public VRegElem {
 class VReg4BList : public VRegList {
  public:
   VReg4BList(const VReg4B &s);
-  explicit VReg4BList(const VRegVec &s, const VRegVec &e)
+  VReg4BList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegBElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -255,7 +255,7 @@ class VReg4BList : public VRegList {
 class VReg8BList : public VRegList {
  public:
   VReg8BList(const VReg8B &s);
-  explicit VReg8BList(const VRegVec &s, const VRegVec &e)
+  VReg8BList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegBElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -265,7 +265,7 @@ class VReg8BList : public VRegList {
 class VReg16BList : public VRegList {
  public:
   VReg16BList(const VReg16B &s);
-  explicit VReg16BList(const VRegVec &s, const VRegVec &e)
+  VReg16BList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegBElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -275,7 +275,7 @@ class VReg16BList : public VRegList {
 class VReg2HList : public VRegList {
  public:
   VReg2HList(const VReg2H &s);
-  explicit VReg2HList(const VRegVec &s, const VRegVec &e)
+  VReg2HList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegHElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -285,7 +285,7 @@ class VReg2HList : public VRegList {
 class VReg4HList : public VRegList {
  public:
   VReg4HList(const VReg4H &s);
-  explicit VReg4HList(const VRegVec &s, const VRegVec &e)
+  VReg4HList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegHElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -295,7 +295,7 @@ class VReg4HList : public VRegList {
 class VReg8HList : public VRegList {
  public:
   VReg8HList(const VReg8H &s);
-  explicit VReg8HList(const VRegVec &s, const VRegVec &e)
+  VReg8HList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegHElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -305,7 +305,7 @@ class VReg8HList : public VRegList {
 class VReg2SList : public VRegList {
  public:
   VReg2SList(const VReg2S &s);
-  explicit VReg2SList(const VRegVec &s, const VRegVec &e)
+  VReg2SList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegSElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -315,7 +315,7 @@ class VReg2SList : public VRegList {
 class VReg4SList : public VRegList {
  public:
   VReg4SList(const VReg4S &s);
-  explicit VReg4SList(const VRegVec &s, const VRegVec &e)
+  VReg4SList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegSElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -325,7 +325,7 @@ class VReg4SList : public VRegList {
 class VReg1DList : public VRegList {
  public:
   VReg1DList(const VReg1D &s);
-  explicit VReg1DList(const VRegVec &s, const VRegVec &e)
+  VReg1DList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegDElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -335,7 +335,7 @@ class VReg1DList : public VRegList {
 class VReg2DList : public VRegList {
  public:
   VReg2DList(const VReg2D &s);
-  explicit VReg2DList(const VRegVec &s, const VRegVec &e)
+  VReg2DList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegDElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -345,7 +345,7 @@ class VReg2DList : public VRegList {
 class VReg1QList : public VRegList {
  public:
   VReg1QList(const VReg1Q &s);
-  explicit VReg1QList(const VRegVec &s, const VRegVec &e)
+  VReg1QList(const VRegVec &s, const VRegVec &e)
     : VRegList(s, e) {}
   VRegQElem operator[](uint32_t i) const {
     assert(getLane() > i);
@@ -475,18 +475,17 @@ class VReg1Q : public VRegVec {
   }
 };
 
-#ifdef XBYAK_AARCH64_OBJ
-VReg8BList::VReg8BList(const VReg8B &s) : VRegList(s, s){};
-VReg16BList::VReg16BList(const VReg16B &s) : VRegList(s, s){};
-VReg2HList::VReg2HList(const VReg2H &s) : VRegList(s, s){};
-VReg4HList::VReg4HList(const VReg4H &s) : VRegList(s, s){};
-VReg8HList::VReg8HList(const VReg8H &s) : VRegList(s, s){};
-VReg2SList::VReg2SList(const VReg2S &s) : VRegList(s, s){};
-VReg4SList::VReg4SList(const VReg4S &s) : VRegList(s, s){};
-VReg1DList::VReg1DList(const VReg1D &s) : VRegList(s, s){};
-VReg2DList::VReg2DList(const VReg2D &s) : VRegList(s, s){};
-VReg1QList::VReg1QList(const VReg1Q &s) : VRegList(s, s){};
-#endif  // #ifdef XBYAK_AARCH64_OBJ
+inline VReg4BList::VReg4BList(const VReg4B &s) : VRegList(s, s) {}
+inline VReg8BList::VReg8BList(const VReg8B &s) : VRegList(s, s) {}
+inline VReg16BList::VReg16BList(const VReg16B &s) : VRegList(s, s) {}
+inline VReg2HList::VReg2HList(const VReg2H &s) : VRegList(s, s) {}
+inline VReg4HList::VReg4HList(const VReg4H &s) : VRegList(s, s) {}
+inline VReg8HList::VReg8HList(const VReg8H &s) : VRegList(s, s) {}
+inline VReg2SList::VReg2SList(const VReg2S &s) : VRegList(s, s) {}
+inline VReg4SList::VReg4SList(const VReg4S &s) : VRegList(s, s) {}
+inline VReg1DList::VReg1DList(const VReg1D &s) : VRegList(s, s) {}
+inline VReg2DList::VReg2DList(const VReg2D &s) : VRegList(s, s) {}
+inline VReg1QList::VReg1QList(const VReg1Q &s) : VRegList(s, s) {}
 
 // SIMD vector regisetr
 class VReg : public VRegVec {


### PR DESCRIPTION
XBYAK_AARCH64_OBJ is difficult to handle, so it is better to be removed.