### PR TITLE
Fix wrong fmov

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/herumi/xbyak_aarch64.png)](https://travis-ci.org/herumi/xbyak_aarch64)
+
 # Xbyak_aarch64 ; JIT assembler for AArch64 CPUs by C++
 
 ## Abstract

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -325,7 +325,7 @@ class CodeGenUtil {
     uint32_t sign = (imm < 0) ? 1 : 0;
 
     imm = std::abs(imm);
-    int32_t max_digit = static_cast<uint32_t>(std::floor(std::log2(imm)));
+    int32_t max_digit = static_cast<int32_t>(std::floor(std::log2(imm)));
 
     int32_t n = (size == 16) ? 7 : (size == 32) ? 10 : 13;
     int32_t exp = (max_digit - 1) + (1 << n);


### PR DESCRIPTION
The conversion from a negative value of `double` type to `uint32_t` is undefined behavior, so we should use `int32_t` type.