### PR TITLE
disable setCodeInfo to reduce compile time

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_mnemonic.h
+++ b/xbyak_aarch64/xbyak_aarch64_mnemonic.h
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-#define XBYAK_SET_CODE_INFO() setCodeInfo(__FILE__, __LINE__, __func__)
+#ifdef XBYAK_USE_FILE_LINE
+  #define XBYAK_SET_CODE_INFO() setCodeInfo(__FILE__, __LINE__, __func__)
+#else
+  #define XBYAK_SET_CODE_INFO()
+#endif
 void adr(const XReg &xd, const Label &label) {
   XBYAK_SET_CODE_INFO();
   PCrelAddr(0, xd, label);


### PR DESCRIPTION
setCodeInfo is disabled unless XBYAK_USE_FILE_LINE to reduce compile time.
The time of a tiny test is reduced from 12 sec to 10 sec.