### PR TITLE
change meaning of getCode()/getSize()

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The following dpkgs are required.
 Then execute the following commands.
 ```
 cd xbyak_aarch64/sample
-aarch64-linux-gnu-g++ add.cpp
-env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu qemu-aarch64 ./a.out
+aarch64-linux-gnu-g++ add.cpp -include test/workaround.hpp
+env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu qemu-aarch64 -cpu max,sve512=on ./a.out
 ```
 
 ## How to use Xbyak_aarch64

--- a/sample/add.cpp
+++ b/sample/add.cpp
@@ -17,20 +17,16 @@
 using namespace Xbyak;
 class Generator : public CodeGenerator {
 public:
-    void genAddFunc() {
+    Generator() {
         Label L1,L2;
         add(w0,w1,w0);
         ret();
     }
-    const uint32_t *gen() {
-        genAddFunc();
-        ready();
-        return getCode();
-    }
 };
 int main() {
     Generator gen;
-    int (*f)(int a, int b) = (int (*)(int a, int b))gen.gen();
+    gen.ready();
+    int (*f)(int a, int b) = gen.getCode<int (*)(int a, int b)>();
     //    gen.dump();
     std::cout << f(3,4) << std::endl;
     return 0;

--- a/sample/label.cpp
+++ b/sample/label.cpp
@@ -17,7 +17,7 @@
 using namespace Xbyak;
 class Generator : public CodeGenerator {
 public:
-    void genAddFunc() {
+    Generator() {
         Label L1,L2;
         L(L1);
         add(w0,w1,w0);
@@ -28,15 +28,11 @@ public:
         L(L2);
         ret();
     }
-    const uint32_t *gen() {
-        genAddFunc();
-        ready();
-        return getCode();
-    }
 };
 int main() {
     Generator gen;
-    int (*f)(int a, int b) = (int (*)(int a, int b))gen.gen();
+    gen.ready();
+    int (*f)(int a, int b) = gen.getCode<int (*)(int a, int b)>();
     std::cout << f(3,4) << std::endl;
     return 0;
 }

--- a/test/workaround.hpp
+++ b/test/workaround.hpp
@@ -1,0 +1,4 @@
+#define CodeGeneratorAArch64 CodeGenerator
+#define LabelAArch64 Label
+#define Xbyak Xbyak_aarch64
+#define L_aarch64 L

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -125,6 +125,7 @@ class CodeArrayAArch64 {
   AllocatorAArch64 *alloc_;
 
  protected:
+  friend class LabelManagerAArch64;
   size_t maxSize_;  // max size of code size (per uint32_t)
   uint32_t *top_;
   size_t size_;  // code size
@@ -231,7 +232,6 @@ class CodeArrayAArch64 {
   const F getCurr() const {
     return reinterpret_cast<F>(&top_[size_]);
   }
-  size_t getUint32Num() const { return size_; }
   // return byte size
   size_t getSize() const { return size_; }
   size_t getMaxSize() const { return maxSize_ * CSIZE; }

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -27,7 +27,7 @@ inline void *AlignedMalloc(size_t size, size_t alignment) {
   return _aligned_malloc(size, alignment);
 #else
   void *p;
-  int ret = posix_memalign(&p, alignment, size * CSIZE);
+  int ret = posix_memalign(&p, alignment, size);
   return (ret == 0) ? p : 0;
 #endif
 }
@@ -70,7 +70,7 @@ class MmapAllocatorAArch64 : AllocatorAArch64 {
 #else
 #error "not supported"
 #endif
-    void *p = mmap(NULL, size * CSIZE, PROT_READ | PROT_WRITE, mode, -1, 0);
+    void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
     if (p == MAP_FAILED) throw Error(ERR_CANT_ALLOC);
     assert(p);
     sizeList_[(uintptr_t)p] = size;
@@ -125,7 +125,7 @@ class CodeArrayAArch64 {
   AllocatorAArch64 *alloc_;
 
  protected:
-  size_t maxSize_;  // max size of code size
+  size_t maxSize_;  // max size of code size (per uint32_t)
   uint32_t *top_;
   size_t size_;  // code size
   bool isCalledCalcJmpAddress_;
@@ -136,13 +136,13 @@ class CodeArrayAArch64 {
   */
   void growMemory() {
     const size_t newSize =
-        (std::max<size_t>)(DEFAULT_MAX_CODE_SIZE, maxSize_ * 2);
+        (std::max<size_t>)(DEFAULT_MAX_CODE_SIZE, getMaxSize() * 2);
     uint32_t *newTop = alloc_->alloc(newSize);
     if (newTop == 0) throw Error(ERR_CANT_ALLOC);
     for (size_t i = 0; i < size_; i++) newTop[i] = top_[i];
     alloc_->free(top_);
     top_ = newTop;
-    maxSize_ = newSize;
+    maxSize_ = newSize / CSIZE;
   }
   /*
     calc jmp address for AutoGrow mode
@@ -171,9 +171,9 @@ class CodeArrayAArch64 {
                   : (userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF
                                                                    : USER_BUF),
         alloc_(allocator ? allocator : (AllocatorAArch64 *)&defaultAllocator_),
-        maxSize_(maxSize),
+        maxSize_(maxSize / CSIZE),
         top_(type_ == USER_BUF ? reinterpret_cast<uint32_t *>(userPtr)
-                               : alloc_->alloc((std::max<size_t>)(maxSize, 1))),
+                               : alloc_->alloc((std::max<size_t>)(maxSize, 4))),
         size_(0),
         isCalledCalcJmpAddress_(false) {
     if (maxSize_ > 0 && top_ == 0) throw Error(ERR_CANT_ALLOC);
@@ -190,7 +190,7 @@ class CodeArrayAArch64 {
     }
   }
   bool setProtectMode(ProtectMode mode, bool throwException = true) {
-    bool isOK = protect(top_, maxSize_, mode);
+    bool isOK = protect(top_, getMaxSize(), mode);
     if (isOK) return true;
     if (throwException) throw Error(ERR_CANT_PROTECT);
     return false;
@@ -221,41 +221,28 @@ class CodeArrayAArch64 {
     }
     top_[size_++] = code;
   }
-#ifdef XBYAK_TRANSLATE_AARCH64
   const uint8_t *getCode() const { return reinterpret_cast<uint8_t *>(top_); }
-  const uint32_t *getCode32() const { return top_; }
-#else
-  const uint32_t *getCode() const { return top_; }
-#endif
   template <class F>
   const F getCode() const {
     return reinterpret_cast<F>(top_);
   }
-#ifdef XBYAK_TRANSLATE_AARCH64
   const uint8_t *getCurr() const { return reinterpret_cast<uint8_t *>(&top_[size_]); }
-  const uint32_t *getCurr32() const { return &top_[size_]; }
-#else
-  const uint32_t *getCurr() const { return &top_[size_]; }
-#endif
   template <class F>
   const F getCurr() const {
     return reinterpret_cast<F>(&top_[size_]);
   }
+  size_t getUint32Num() const { return size_; }
+  // return byte size
   size_t getSize() const { return size_; }
+  size_t getMaxSize() const { return maxSize_ * CSIZE; }
+  // set byte size
   void setSize(size_t size) {
-    if (size > maxSize_) throw Error(ERR_OFFSET_IS_TOO_BIG);
-    size_ = size;
+    if (size > getMaxSize()) throw Error(ERR_OFFSET_IS_TOO_BIG);
+    size_ = size / CSIZE;
   }
   void dump() const {
-#ifdef XBYAK_TRANSLATE_AARCH64
-    const uint8_t *p = getCode();
-#else
-    const uint32_t *p = getCode();
-#endif
-    size_t bufSize = getSize();
-    size_t remain = bufSize;
-    for (size_t i = 0; i < remain; ++i) {
-      printf("%08X\n", p[i]);
+    for (size_t i = 0; i < size_; ++i) {
+      printf("%08X\n", top_[i]);
     }
   }
   /*

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -556,7 +556,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
   // set infomation of instruction code
   void setCodeInfo(const std::string &file, size_t line,
                    const std::string &func) {
-    cinfo_.set(getUint32Num(), file, line, func);
+    cinfo_.set(size_, file, line, func);
     updateCodeInfoHist();
   }
 
@@ -690,7 +690,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     size_t offset = 0;
     int64_t labelOffset = 0;
     if (labelMgr_.getOffset(&offset, label)) {
-      labelOffset = (offset - getUint32Num()) * CSIZE;
+      labelOffset = (offset - size_) * CSIZE;
     } else {
       labelMgr_.addUndefinedLabel(label, jmpL);
     }
@@ -718,7 +718,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op, rd](int64_t labelOffset) {
       return PCrelAddrEnc(op, rd, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = PCrelAddrEnc(op, rd, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -847,7 +847,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, cond](int64_t labelOffset) {
       return CondBrImmEnc(cond, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = CondBrImmEnc(cond, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -984,7 +984,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op](int64_t labelOffset) {
       return UncondBrImmEnc(op, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = UncondBrImmEnc(op, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1009,7 +1009,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op](int64_t labelOffset) {
       return CompareBrEnc(op, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = CompareBrEnc(op, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1040,7 +1040,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op, rt, imm](int64_t labelOffset) {
       return TestBrEnc(op, rt, imm, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = TestBrEnc(op, rt, imm, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1386,7 +1386,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, opc, V, rt](int64_t labelOffset) {
       return LdRegLiteralEnc(opc, V, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = LdRegLiteralEnc(opc, V, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1412,7 +1412,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, vt](int64_t labelOffset) {
       return LdRegSimdFpLiteralEnc(vt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = LdRegSimdFpLiteralEnc(vt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1437,7 +1437,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, prfop](int64_t labelOffset) {
       return PfLiteralEnc(prfop, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
     uint32_t code = PfLiteralEnc(prfop, genLabelOffset(label, jmpL));
     dw(code);
   }

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -556,7 +556,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
   // set infomation of instruction code
   void setCodeInfo(const std::string &file, size_t line,
                    const std::string &func) {
-    cinfo_.set(getSize(), file, line, func);
+    cinfo_.set(getUint32Num(), file, line, func);
     updateCodeInfoHist();
   }
 
@@ -690,7 +690,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     size_t offset = 0;
     int64_t labelOffset = 0;
     if (labelMgr_.getOffset(&offset, label)) {
-      labelOffset = (offset - getSize()) * CSIZE;
+      labelOffset = (offset - getUint32Num()) * CSIZE;
     } else {
       labelMgr_.addUndefinedLabel(label, jmpL);
     }
@@ -718,7 +718,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op, rd](int64_t labelOffset) {
       return PCrelAddrEnc(op, rd, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = PCrelAddrEnc(op, rd, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -847,7 +847,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, cond](int64_t labelOffset) {
       return CondBrImmEnc(cond, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = CondBrImmEnc(cond, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -984,7 +984,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op](int64_t labelOffset) {
       return UncondBrImmEnc(op, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = UncondBrImmEnc(op, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1009,7 +1009,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op](int64_t labelOffset) {
       return CompareBrEnc(op, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = CompareBrEnc(op, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1040,7 +1040,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, op, rt, imm](int64_t labelOffset) {
       return TestBrEnc(op, rt, imm, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = TestBrEnc(op, rt, imm, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1386,7 +1386,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, opc, V, rt](int64_t labelOffset) {
       return LdRegLiteralEnc(opc, V, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = LdRegLiteralEnc(opc, V, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1412,7 +1412,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, vt](int64_t labelOffset) {
       return LdRegSimdFpLiteralEnc(vt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = LdRegSimdFpLiteralEnc(vt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1437,7 +1437,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
     auto encFunc = [&, prfop](int64_t labelOffset) {
       return PfLiteralEnc(prfop, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getSize());
+    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, getUint32Num());
     uint32_t code = PfLiteralEnc(prfop, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -5639,7 +5639,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
       calcJmpAddress();
       if (useProtect()) setProtectMode(mode);
     }
-    clearCache(const_cast<uint32_t*>(getCode()), const_cast<uint32_t*>(getCurr()));
+    clearCache(const_cast<uint8_t*>(getCode()), const_cast<uint8_t*>(getCurr()));
   }
   // set read/exec
   void readyRE() { return ready(PROTECT_RE); }

--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -158,7 +158,7 @@ class LabelManagerAArch64 {
 
   void defineClabel(LabelAArch64& label) {
     define_inner(clabelDefListAArch64_, clabelUndefListAArch64_, getId(label),
-                 base_->getUint32Num());
+                 base_->size_);
     label.mgr = this;
     labelPtrListAArch64_.insert(&label);
   }

--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -158,7 +158,7 @@ class LabelManagerAArch64 {
 
   void defineClabel(LabelAArch64& label) {
     define_inner(clabelDefListAArch64_, clabelUndefListAArch64_, getId(label),
-                 base_->getSize());
+                 base_->getUint32Num());
     label.mgr = this;
     labelPtrListAArch64_.insert(&label);
   }
@@ -178,12 +178,7 @@ class LabelManagerAArch64 {
   bool hasUndefClabel() const {
     return hasUndefinedLabel_inner(clabelUndefListAArch64_);
   }
-#ifdef XBYAK_TRANSLATE_AARCH64
   const uint8_t* getCode() const { return base_->getCode(); }
-  const uint32_t* getCode32() const { return base_->getCode32(); }
-#else
-  const uint32_t* getCode() const { return base_->getCode(); }
-#endif
   bool isReady() const {
     return !base_->isAutoGrow() || base_->isCalledCalcJmpAddress();
   }
@@ -208,11 +203,7 @@ inline const uint32_t* LabelAArch64::getAddress() const {
   if (mgr == 0 || !mgr->isReady()) return 0;
   size_t offset;
   if (!mgr->getOffset(&offset, *this)) return 0;
-#ifdef XBYAK_TRANSLATE_AARCH64
-  return mgr->getCode32() + offset * CSIZE;
-#else
-  return mgr->getCode() + offset * CSIZE;
-#endif
+  return (const uint32_t*)mgr->getCode() + offset;
 }
 
 #endif


### PR DESCRIPTION
- The current the return value of getSize() and the size of AllocatorAArch64::alloca(size) are not byte but uint32_t, so they are misleading.
- `maxSize_` should be the num of uint32_t because it is compared with `size_`.

So I modified as the followings:
- rename `getSize()` to `getUint32Num()` and add `getSize()` which returns byte size.
- change the return type of `getCode()` from `uint32_t*` to `uint8_t*` like as the original xbyak.
- etc.
