### PR TITLE
Rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ You can use "label" to direct where branch instruction jump to.
 The following example shows how to use "label".
 
 ```
-LabelAArch64 L1;           // (1), instance of LabelAArch64 class
+Label L1;           // (1), instance of Label class
  
 mov(w4, w0); 
 mov(w3, 0); 
@@ -540,7 +540,7 @@ bgt(L1);            // (3), set destination of branch instruction to the address
 You can copy the address stored in "Label" instance by using assignL function.
 
 ```
-LabelAArch64 L1,L2,L3; 
+Label L1,L2,L3;
 ....
 L(L1);               // JIT code address of this position is stored to L1.
 ....

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The following dpkgs are required.
 Then execute the following commands.
 ```
 cd xbyak_aarch64/sample
-aarch64-linux-gnu-g++ add.cpp -include test/workaround.hpp
+aarch64-linux-gnu-g++ add.cpp
 env QEMU_LD_PREFIX=/usr/aarch64-linux-gnu qemu-aarch64 -cpu max,sve512=on ./a.out
 ```
 
@@ -525,7 +525,7 @@ LabelAArch64 L1;           // (1), instance of LabelAArch64 class
 mov(w4, w0); 
 mov(w3, 0); 
 mov(w0, 0); 
-L_aarch64(L1);              // (2), "L" function registers JIT code address of this position to label L1.
+L(L1);              // (2), "L" function registers JIT code address of this position to label L1.
 add(w0, w0, w4); 
 add(w3, w3, 1); 
 cmp(w2, w3); 
@@ -542,9 +542,9 @@ You can copy the address stored in "Label" instance by using assignL function.
 ```
 LabelAArch64 L1,L2,L3; 
 ....
-L_aarch64(L1);               // JIT code address of this position is stored to L1.
+L(L1);               // JIT code address of this position is stored to L1.
 ....
-L_aarch64(L2);               // JIT code address of this position is stored to L1.
+L(L2);               // JIT code address of this position is stored to L1.
 ....
 if (flag) { 
 assignL(L3,L1);      // The address stored in L1 is copied to L3.

--- a/sample/add.cpp
+++ b/sample/add.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 #include "../xbyak_aarch64/xbyak_aarch64.h"
-using namespace Xbyak;
+using namespace Xbyak_aarch64;
 class Generator : public CodeGenerator {
 public:
     Generator() {

--- a/sample/label.cpp
+++ b/sample/label.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 #include "../xbyak_aarch64/xbyak_aarch64.h"
-using namespace Xbyak;
+using namespace Xbyak_aarch64;
 class Generator : public CodeGenerator {
 public:
     Generator() {

--- a/test/nm_frame.cpp
+++ b/test/nm_frame.cpp
@@ -24,7 +24,7 @@ using namespace Xbyak_aarch64;
 	#pragma warning(disable : 4245)
 	#pragma warning(disable : 4312)
 #endif
-class Sample : public CodeGeneratorAArch64 {
+class Sample : public CodeGenerator {
 	void operator=(const Sample&);
 public:
 #include "nm.cpp"
@@ -33,7 +33,7 @@ public:
 #define _STR(x) #x
 #define TEST(syntax) err = true; try { syntax; err = false; } catch (Xbyak::Error) { } catch (...) { } if (!err) printf("should be err:%s;\n", _STR(syntax))
 
-class ErrorSample : public CodeGeneratorAArch64 {
+class ErrorSample : public CodeGenerator {
 	void operator=(const ErrorSample&);
 public:
 	void gen()

--- a/test/workaround.hpp
+++ b/test/workaround.hpp
@@ -1,4 +1,4 @@
-#define CodeGeneratorAArch64 CodeGenerator
+#define CodeGenerator CodeGenerator
 #define LabelAArch64 Label
 #define Xbyak Xbyak_aarch64
 #define L_aarch64 L

--- a/test/workaround.hpp
+++ b/test/workaround.hpp
@@ -1,4 +1,2 @@
-#define CodeGenerator CodeGenerator
-#define LabelAArch64 Label
 #define Xbyak Xbyak_aarch64
 #define L_aarch64 L

--- a/test/workaround.hpp
+++ b/test/workaround.hpp
@@ -1,2 +1,0 @@
-#define Xbyak Xbyak_aarch64
-#define L_aarch64 L

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -207,6 +207,12 @@ class CodeArrayAArch64 {
     addrInfoList_.clear();
     isCalledCalcJmpAddress_ = false;
   }
+  void clearCodeArray() {
+    for(size_t i = 0; i < size_; i++){
+      top_[i] = 0;
+    }
+    size_ = 0;
+  }
 
 #ifdef XBYAK_TRANSLATE_AARCH64
   void dw_aarch64(uint32_t code) {

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -117,7 +117,7 @@ enum Pattern {
 
 enum IcOp {
 #ifdef XBYAK_TRANSLATE_AARCH64
-  ALLUIS = Xbyak::Xbyak_aarch64::inner::genSysInstOp(0, 7, 1, 0),  // op1=0, CRn=7, CRm=1, op2=0
+  ALLUIS = Xbyak_aarch64::inner::genSysInstOp(0, 7, 1, 0),  // op1=0, CRn=7, CRm=1, op2=0
 #else
   ALLUIS = inner::genSysInstOp(0, 7, 1, 0),  // op1=0, CRn=7, CRm=1, op2=0
 #endif

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -116,11 +116,7 @@ enum Pattern {
 };
 
 enum IcOp {
-#ifdef XBYAK_TRANSLATE_AARCH64
-  ALLUIS = Xbyak_aarch64::inner::genSysInstOp(0, 7, 1, 0),  // op1=0, CRn=7, CRm=1, op2=0
-#else
   ALLUIS = inner::genSysInstOp(0, 7, 1, 0),  // op1=0, CRn=7, CRm=1, op2=0
-#endif
   ALLU = inner::genSysInstOp(0, 7, 5, 0),    // op1=0, CRn=7, CRm=5, op2=0
   VAU = inner::genSysInstOp(3, 7, 5, 0)      // op1=3, CRn=7, CRm=5, op2=1
 };

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -686,7 +686,7 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
   }
 
   // generate relative address for label offset
-  uint64_t genLabelOffset(const LabelAArch64 &label, const JmpLabelAArch64&jmpL) {
+  uint64_t genLabelOffset(const Label &label, const JmpLabel&jmpL) {
     size_t offset = 0;
     int64_t labelOffset = 0;
     if (labelMgr_.getOffset(&offset, label)) {
@@ -714,11 +714,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
 #define dw dw_aarch64  
 #endif
 
-  void PCrelAddr(uint32_t op, const XReg &rd, const LabelAArch64&label) {
+  void PCrelAddr(uint32_t op, const XReg &rd, const Label&label) {
     auto encFunc = [&, op, rd](int64_t labelOffset) {
       return PCrelAddrEnc(op, rd, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = PCrelAddrEnc(op, rd, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -843,11 +843,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
     return concat({F(0x2a, 25), F(imm19, 5), F(cond, 0)});
   }
 
-  void CondBrImm(Cond cond, const LabelAArch64&label) {
+  void CondBrImm(Cond cond, const Label&label) {
     auto encFunc = [&, cond](int64_t labelOffset) {
       return CondBrImmEnc(cond, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = CondBrImmEnc(cond, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -980,11 +980,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
     return concat({F(op, 31), F(5, 26), F(imm26, 0)});
   }
 
-  void UncondBrImm(uint32_t op, const LabelAArch64&label) {
+  void UncondBrImm(uint32_t op, const Label&label) {
     auto encFunc = [&, op](int64_t labelOffset) {
       return UncondBrImmEnc(op, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = UncondBrImmEnc(op, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1005,11 +1005,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
         {F(sf, 31), F(0x1a, 25), F(op, 24), F(imm19, 5), F(rt.getIdx(), 0)});
   }
 
-  void CompareBr(uint32_t op, const RReg &rt, const LabelAArch64&label) {
+  void CompareBr(uint32_t op, const RReg &rt, const Label&label) {
     auto encFunc = [&, op](int64_t labelOffset) {
       return CompareBrEnc(op, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = CompareBrEnc(op, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1036,11 +1036,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
                    F(rt.getIdx(), 0)});
   }
 
-  void TestBr(uint32_t op, const RReg &rt, uint32_t imm, const LabelAArch64&label) {
+  void TestBr(uint32_t op, const RReg &rt, uint32_t imm, const Label&label) {
     auto encFunc = [&, op, rt, imm](int64_t labelOffset) {
       return TestBrEnc(op, rt, imm, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = TestBrEnc(op, rt, imm, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1382,11 +1382,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
   }
 
   void LdRegLiteral(uint32_t opc, uint32_t V, const RReg &rt,
-                    const LabelAArch64&label) {
+                    const Label&label) {
     auto encFunc = [&, opc, V, rt](int64_t labelOffset) {
       return LdRegLiteralEnc(opc, V, rt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = LdRegLiteralEnc(opc, V, rt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1408,11 +1408,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
         {F(opc, 30), F(0x3, 27), F(V, 26), F(imm19, 5), F(vt.getIdx(), 0)});
   }
 
-  void LdRegSimdFpLiteral(const VRegSc &vt, const LabelAArch64&label) {
+  void LdRegSimdFpLiteral(const VRegSc &vt, const Label&label) {
     auto encFunc = [&, vt](int64_t labelOffset) {
       return LdRegSimdFpLiteralEnc(vt, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = LdRegSimdFpLiteralEnc(vt, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -1433,11 +1433,11 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
     return concat({F(opc, 30), F(0x3, 27), F(V, 26), F(imm19, 5), F(prfop, 0)});
   }
 
-  void PfLiteral(Prfop prfop, const LabelAArch64&label) {
+  void PfLiteral(Prfop prfop, const Label&label) {
     auto encFunc = [&, prfop](int64_t labelOffset) {
       return PfLiteralEnc(prfop, labelOffset);
     };
-    JmpLabelAArch64 jmpL = JmpLabelAArch64(encFunc, size_);
+    JmpLabel jmpL = JmpLabel(encFunc, size_);
     uint32_t code = PfLiteralEnc(prfop, genLabelOffset(label, jmpL));
     dw(code);
   }
@@ -5203,7 +5203,7 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
 #ifdef XBYAK_TRANSLATE_AARCH64
 #undef dw
 
-  void mov(const XReg &rd, const LabelAArch64 &label) {
+  void mov(const XReg &rd, const Label &label) {
     adr(rd, label);
   }
 #endif
@@ -5598,9 +5598,9 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
     labelMgr_.set(this);
   }
 
-  void L_aarch64(LabelAArch64 &label) { labelMgr_.defineClabel(label); }
-  LabelAArch64 L_aarch64() {
-      LabelAArch64 label;
+  void L_aarch64(Label &label) { labelMgr_.defineClabel(label); }
+  Label L_aarch64() {
+      Label label;
     L_aarch64(label);
     return label;
   }
@@ -5612,12 +5612,12 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
           dst : does not used by L()
           src : used by L()
   */
-  void assignL(LabelAArch64&dst, const LabelAArch64&src) { labelMgr_.assign(dst, src); }
+  void assignL(Label&dst, const Label&src) { labelMgr_.assign(dst, src); }
   /*
           put address of label to buffer
           @note the put size is 4(32-bit), 8(64-bit)
   */
-  void putL(const LabelAArch64&label) { putL_inner(label); }
+  void putL(const Label&label) { putL_inner(label); }
 
   void reset() {
     resetSize();

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -523,7 +523,7 @@ class CodeGenUtil {
   }
 };
 
-class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
+class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
   struct CodeInfo {
     size_t code_idx;
     std::string file;
@@ -5260,7 +5260,7 @@ class CodeGeneratorAArch64 : public CodeGenUtil, public CodeArrayAArch64 {
   const PReg p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12;
   const PReg p13, p14, p15;
 
-  CodeGeneratorAArch64(size_t maxSize = DEFAULT_MAX_CODE_SIZE, void *userPtr = 0,
+  CodeGenerator(size_t maxSize = DEFAULT_MAX_CODE_SIZE, void *userPtr = 0,
                 AllocatorAArch64 *allocator = 0)
       : CodeArrayAArch64(maxSize, userPtr, allocator)
 #if 1

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -5598,10 +5598,10 @@ class CodeGenerator : public CodeGenUtil, public CodeArrayAArch64 {
     labelMgr_.set(this);
   }
 
-  void L_aarch64(Label &label) { labelMgr_.defineClabel(label); }
-  Label L_aarch64() {
+  void L(Label &label) { labelMgr_.defineClabel(label); }
+  Label L() {
       Label label;
-    L_aarch64(label);
+    L(label);
     return label;
   }
   void inLocalLabel() { /*assert(NULL);*/ }

--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -51,10 +51,6 @@ class Label {
   const uint32_t* getAddress() const;
 };
 
-#ifdef XBYAK_TRANSLATE_AARCH64
-  using namespace Xbyak::Xbyak_aarch64;
-#endif
-
 class LabelManagerAArch64 {
 
   // for Label class

--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -22,27 +22,27 @@
 #include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
 
-struct JmpLabelAArch64 {
+struct JmpLabel {
   // type of partially applied function for encoding
   typedef std::function<uint32_t(int64_t)> EncFunc;
   size_t endOfJmp; /* offset from top to the end address of jmp */
   EncFunc encFunc;
-  explicit JmpLabelAArch64(const EncFunc& encFunc, size_t endOfJmp = 0)
+  explicit JmpLabel(const EncFunc& encFunc, size_t endOfJmp = 0)
       : endOfJmp(endOfJmp), encFunc(encFunc) {}
 };
 
 class LabelManagerAArch64;
 
-class LabelAArch64 {
+class Label {
   mutable LabelManagerAArch64* mgr;
   mutable int id;
   friend class LabelManagerAArch64;
 
  public:
-     LabelAArch64() : mgr(nullptr), id(0) {}
-     LabelAArch64(const LabelAArch64& rhs);
-     LabelAArch64& operator=(const LabelAArch64& rhs);
-  ~LabelAArch64();
+     Label() : mgr(nullptr), id(0) {}
+     Label(const Label& rhs);
+     Label& operator=(const Label& rhs);
+  ~Label();
   void clear() {
     mgr = nullptr;
     id = 0;
@@ -64,8 +64,8 @@ class LabelManagerAArch64 {
     int refCount;
   };
   typedef std::unordered_map<int, ClabelValAArch64> ClabelDefListAArch64;
-  typedef std::unordered_multimap<int, const JmpLabelAArch64> ClabelUndefListAArch64;
-  typedef std::unordered_set<LabelAArch64*> LabelPtrListAArch64;
+  typedef std::unordered_multimap<int, const JmpLabel> ClabelUndefListAArch64;
+  typedef std::unordered_set<Label*> LabelPtrListAArch64;
 
   CodeArrayAArch64* base_;
   // global : stateList_.front(), local : stateList_.back()
@@ -74,7 +74,7 @@ class LabelManagerAArch64 {
   ClabelUndefListAArch64 clabelUndefListAArch64_;
   LabelPtrListAArch64 labelPtrListAArch64_;
 
-  int getId(const LabelAArch64& label) const {
+  int getId(const Label& label) const {
     if (label.id == 0) label.id = labelId_++;
     return label.id;
   }
@@ -89,7 +89,7 @@ class LabelManagerAArch64 {
     for (;;) {
       typename UndefList::iterator itr = undefList.find(labelId);
       if (itr == undefList.end()) break;
-      const JmpLabelAArch64* jmp = &itr->second;
+      const JmpLabel* jmp = &itr->second;
       const size_t offset = jmp->endOfJmp;
       int64_t labelOffset = (addrOffset - offset) * CSIZE;
       uint32_t disp = jmp->encFunc(labelOffset);
@@ -109,12 +109,12 @@ class LabelManagerAArch64 {
     *offset = i->second.offset;
     return true;
   }
-  friend class LabelAArch64;
-  void incRefCount(int id, LabelAArch64* label) {
+  friend class Label;
+  void incRefCount(int id, Label* label) {
     clabelDefListAArch64_[id].refCount++;
     labelPtrListAArch64_.insert(label);
   }
-  void decRefCount(int id, LabelAArch64* label) {
+  void decRefCount(int id, Label* label) {
     labelPtrListAArch64_.erase(label);
     ClabelDefListAArch64::iterator i = clabelDefListAArch64_.find(id);
     if (i == clabelDefListAArch64_.end()) return;
@@ -156,23 +156,23 @@ class LabelManagerAArch64 {
 
   void set(CodeArrayAArch64* base) { base_ = base; }
 
-  void defineClabel(LabelAArch64& label) {
+  void defineClabel(Label& label) {
     define_inner(clabelDefListAArch64_, clabelUndefListAArch64_, getId(label),
                  base_->size_);
     label.mgr = this;
     labelPtrListAArch64_.insert(&label);
   }
-  void assign(LabelAArch64& dst, const LabelAArch64& src) {
+  void assign(Label& dst, const Label& src) {
     ClabelDefListAArch64::const_iterator i = clabelDefListAArch64_.find(src.id);
     if (i == clabelDefListAArch64_.end()) throw Error(ERR_LABEL_ISNOT_SET_BY_L);
     define_inner(clabelDefListAArch64_, clabelUndefListAArch64_, dst.id, i->second.offset);
     dst.mgr = this;
     labelPtrListAArch64_.insert(&dst);
   }
-  bool getOffset(size_t* offset, const LabelAArch64& label) const {
+  bool getOffset(size_t* offset, const Label& label) const {
     return getOffset_inner(clabelDefListAArch64_, offset, getId(label));
   }
-  void addUndefinedLabel(const LabelAArch64& label, const JmpLabelAArch64& jmp) {
+  void addUndefinedLabel(const Label& label, const JmpLabel& jmp) {
     clabelUndefListAArch64_.insert(ClabelUndefListAArch64::value_type(label.id, jmp));
   }
   bool hasUndefClabel() const {
@@ -184,22 +184,22 @@ class LabelManagerAArch64 {
   }
 };
 
-inline LabelAArch64::LabelAArch64(const LabelAArch64& rhs) {
+inline Label::Label(const Label& rhs) {
   id = rhs.id;
   mgr = rhs.mgr;
   if (mgr) mgr->incRefCount(id, this);
 }
-inline LabelAArch64& LabelAArch64::operator=(const LabelAArch64& rhs) {
+inline Label& Label::operator=(const Label& rhs) {
   if (id) throw Error(ERR_LABEL_IS_ALREADY_SET_BY_L);
   id = rhs.id;
   mgr = rhs.mgr;
   if (mgr) mgr->incRefCount(id, this);
   return *this;
 }
-inline LabelAArch64::~LabelAArch64() {
+inline Label::~Label() {
   if (id && mgr) mgr->decRefCount(id, this);
 }
-inline const uint32_t* LabelAArch64::getAddress() const {
+inline const uint32_t* Label::getAddress() const {
   if (mgr == 0 || !mgr->isReady()) return 0;
   size_t offset;
   if (!mgr->getOffset(&offset, *this)) return 0;

--- a/xbyak_aarch64/xbyak_aarch64_mnemonic.h
+++ b/xbyak_aarch64/xbyak_aarch64_mnemonic.h
@@ -18,7 +18,7 @@
 #else
   #define XBYAK_SET_CODE_INFO()
 #endif
-void adr(const XReg &xd, const LabelAArch64&label) {
+void adr(const XReg &xd, const Label&label) {
   XBYAK_SET_CODE_INFO();
   PCrelAddr(0, xd, label);
 }
@@ -26,7 +26,7 @@ void adr(const XReg &xd, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   PCrelAddr(0, xd, label);
 }
-void adrp(const XReg &xd, const LabelAArch64&label) {
+void adrp(const XReg &xd, const Label&label) {
   XBYAK_SET_CODE_INFO();
   PCrelAddr(1, xd, label);
 }
@@ -340,7 +340,7 @@ void ror(const XReg &rd, const XReg &rn, const uint32_t imm) {
   XBYAK_SET_CODE_INFO();
   Extract(0, 0, rd, rn, rn, imm);
 }
-void b(const Cond cond, const LabelAArch64 &label) {
+void b(const Cond cond, const Label &label) {
   XBYAK_SET_CODE_INFO();
   CondBrImm(cond, label);
 }
@@ -600,7 +600,7 @@ void blrab(const XReg &rn, const XReg &rm) {
   XBYAK_SET_CODE_INFO();
   UncondBr2Reg(9, 31, 3, rn, rm);
 }
-void b(const LabelAArch64 &label) {
+void b(const Label &label) {
   XBYAK_SET_CODE_INFO();
   UncondBrImm(0, label);
 }
@@ -608,7 +608,7 @@ void b(const int64_t label) {
   XBYAK_SET_CODE_INFO();
   UncondBrImm(0, label);
 }
-void bl(const LabelAArch64 &label) {
+void bl(const Label &label) {
   XBYAK_SET_CODE_INFO();
   UncondBrImm(1, label);
 }
@@ -616,11 +616,11 @@ void bl(const int64_t label) {
   XBYAK_SET_CODE_INFO();
   UncondBrImm(1, label);
 }
-void cbz(const WReg &rt, const LabelAArch64& label) {
+void cbz(const WReg &rt, const Label& label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(0, rt, label);
 }
-void cbz(const XReg &rt, const LabelAArch64& label) {
+void cbz(const XReg &rt, const Label& label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(0, rt, label);
 }
@@ -632,11 +632,11 @@ void cbz(const XReg &rt, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(0, rt, label);
 }
-void cbnz(const WReg &rt, const LabelAArch64 &label) {
+void cbnz(const WReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(1, rt, label);
 }
-void cbnz(const XReg &rt, const LabelAArch64 &label) {
+void cbnz(const XReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(1, rt, label);
 }
@@ -648,11 +648,11 @@ void cbnz(const XReg &rt, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   CompareBr(1, rt, label);
 }
-void tbz(const WReg &rt, const uint32_t imm, const LabelAArch64 &label) {
+void tbz(const WReg &rt, const uint32_t imm, const Label &label) {
   XBYAK_SET_CODE_INFO();
   TestBr(0, rt, imm, label);
 }
-void tbz(const XReg &rt, const uint32_t imm, const LabelAArch64 &label) {
+void tbz(const XReg &rt, const uint32_t imm, const Label &label) {
   XBYAK_SET_CODE_INFO();
   TestBr(0, rt, imm, label);
 }
@@ -664,11 +664,11 @@ void tbz(const XReg &rt, const uint32_t imm, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   TestBr(0, rt, imm, label);
 }
-void tbnz(const WReg &rt, const uint32_t imm, const LabelAArch64 &label) {
+void tbnz(const WReg &rt, const uint32_t imm, const Label &label) {
   XBYAK_SET_CODE_INFO();
   TestBr(1, rt, imm, label);
 }
-void tbnz(const XReg &rt, const uint32_t imm, const LabelAArch64 &label) {
+void tbnz(const XReg &rt, const uint32_t imm, const Label &label) {
   XBYAK_SET_CODE_INFO();
   TestBr(1, rt, imm, label);
 }
@@ -2454,11 +2454,11 @@ void ldapur(const XReg &rt, const AdrImm &adr) {
   XBYAK_SET_CODE_INFO();
   LdaprStlr(3, 1, rt, adr);
 }
-void ldr(const WReg &rt, const LabelAArch64 &label) {
+void ldr(const WReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral((rt.getBit() == 64) ? 1 : 0, 0, rt, label);
 }
-void ldr(const XReg &rt, const LabelAArch64 &label) {
+void ldr(const XReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral((rt.getBit() == 64) ? 1 : 0, 0, rt, label);
 }
@@ -2470,11 +2470,11 @@ void ldr(const XReg &rt, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral((rt.getBit() == 64) ? 1 : 0, 0, rt, label);
 }
-void ldrsw(const WReg &rt, const LabelAArch64 &label) {
+void ldrsw(const WReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral(2, 0, rt, label);
 }
-void ldrsw(const XReg &rt, const LabelAArch64 &label) {
+void ldrsw(const XReg &rt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral(2, 0, rt, label);
 }
@@ -2486,15 +2486,15 @@ void ldrsw(const XReg &rt, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   LdRegLiteral(2, 0, rt, label);
 }
-void ldr(const SReg &vt, const LabelAArch64 &label) {
+void ldr(const SReg &vt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegSimdFpLiteral(vt, label);
 }
-void ldr(const DReg &vt, const LabelAArch64 &label) {
+void ldr(const DReg &vt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegSimdFpLiteral(vt, label);
 }
-void ldr(const QReg &vt, const LabelAArch64 &label) {
+void ldr(const QReg &vt, const Label &label) {
   XBYAK_SET_CODE_INFO();
   LdRegSimdFpLiteral(vt, label);
 }
@@ -2510,7 +2510,7 @@ void ldr(const QReg &vt, const int64_t label) {
   XBYAK_SET_CODE_INFO();
   LdRegSimdFpLiteral(vt, label);
 }
-void prfm(const Prfop prfop, const LabelAArch64 &label) {
+void prfm(const Prfop prfop, const Label &label) {
   XBYAK_SET_CODE_INFO();
   PfLiteral(prfop, label);
 }
@@ -19569,51 +19569,51 @@ void str(const ZReg &zt, const AdrNoOfs &adr) {
 }
 #undef XBYAK_SET_CODE_INFO
 
-void beq(const LabelAArch64 &label) { b(EQ, label); }
+void beq(const Label &label) { b(EQ, label); }
 void beq(int64_t label) { b(EQ, label); }
-void bne(const LabelAArch64 &label) { b(NE, label); }
+void bne(const Label &label) { b(NE, label); }
 void bne(int64_t label) { b(NE, label); }
-void bcs(const LabelAArch64 &label) { b(CS, label); }
+void bcs(const Label &label) { b(CS, label); }
 void bcs(int64_t label) { b(CS, label); }
-void bcc(const LabelAArch64 &label) { b(CC, label); }
+void bcc(const Label &label) { b(CC, label); }
 void bcc(int64_t label) { b(CC, label); }
-void bmi(const LabelAArch64 &label) { b(MI, label); }
+void bmi(const Label &label) { b(MI, label); }
 void bmi(int64_t label) { b(MI, label); }
-void bpl(const LabelAArch64 &label) { b(PL, label); }
+void bpl(const Label &label) { b(PL, label); }
 void bpl(int64_t label) { b(PL, label); }
-void bvs(const LabelAArch64 &label) { b(VS, label); }
+void bvs(const Label &label) { b(VS, label); }
 void bvs(int64_t label) { b(VS, label); }
-void bvc(const LabelAArch64 &label) { b(VC, label); }
+void bvc(const Label &label) { b(VC, label); }
 void bvc(int64_t label) { b(VC, label); }
-void bhi(const LabelAArch64 &label) { b(HI, label); }
+void bhi(const Label &label) { b(HI, label); }
 void bhi(int64_t label) { b(HI, label); }
-void bls(const LabelAArch64 &label) { b(LS, label); }
+void bls(const Label &label) { b(LS, label); }
 void bls(int64_t label) { b(LS, label); }
-void bge(const LabelAArch64 &label) { b(GE, label); }
+void bge(const Label &label) { b(GE, label); }
 void bge(int64_t label) { b(GE, label); }
-void blt(const LabelAArch64 &label) { b(LT, label); }
+void blt(const Label &label) { b(LT, label); }
 void blt(int64_t label) { b(LT, label); }
-void bgt(const LabelAArch64 &label) { b(GT, label); }
+void bgt(const Label &label) { b(GT, label); }
 void bgt(int64_t label) { b(GT, label); }
-void ble(const LabelAArch64 &label) { b(LE, label); }
+void ble(const Label &label) { b(LE, label); }
 void ble(int64_t label) { b(LE, label); }
-void b_none(const LabelAArch64& label) { beq(label); }
+void b_none(const Label& label) { beq(label); }
 void b_none(int64_t label) { beq(label); }
-void b_any(const LabelAArch64& label) { bne(label); }
+void b_any(const Label& label) { bne(label); }
 void b_any(int64_t label) { bne(label); }
-void b_nlast(const LabelAArch64& label) { bcs(label); }
+void b_nlast(const Label& label) { bcs(label); }
 void b_nlast(int64_t label) { bcs(label); }
-void b_last(const LabelAArch64& label) { bcc(label); }
+void b_last(const Label& label) { bcc(label); }
 void b_last(int64_t label) { bcc(label); }
-void b_first(const LabelAArch64& label) { bmi(label); }
+void b_first(const Label& label) { bmi(label); }
 void b_first(int64_t label) { bmi(label); }
-void b_nfrst(const LabelAArch64& label) { bpl(label); }
+void b_nfrst(const Label& label) { bpl(label); }
 void b_nfrst(int64_t label) { bpl(label); }
-void b_pmore(const LabelAArch64& label) { bhi(label); }
+void b_pmore(const Label& label) { bhi(label); }
 void b_pmore(int64_t label) { bhi(label); }
-void b_plast(const LabelAArch64& label) { bls(label); }
+void b_plast(const Label& label) { bls(label); }
 void b_plast(int64_t label) { bls(label); }
-void b_tcont(const LabelAArch64& label) { bge(label); }
+void b_tcont(const Label& label) { bge(label); }
 void b_tcont(int64_t label) { bge(label); }
-void b_tstop(const LabelAArch64& label) { blt(label); }
+void b_tstop(const Label& label) { blt(label); }
 void b_tstop(int64_t label) { blt(label); }


### PR DESCRIPTION
Rename the class/function names to minimize the difference between fjmaster and master.

- CodeGeneratorAArch64 -> CodeGenerator
- LabelAArch64 -> Label
- L_aarch64 -> L