### PR TITLE
Support large page

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -227,7 +227,7 @@ public:
     dd(code);
   }
   void dw_aarch64(uint32_t code) __attribute__((deprecated)) {
-    dw(code);
+    dd(code);
   }
 
   // write 4 byte data

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -45,7 +45,7 @@ template <class To, class From> inline const To CastTo(From p) throw() {
 struct AllocatorAArch64 {
   virtual uint32_t *alloc(size_t size) {
     return reinterpret_cast<uint32_t *>(
-        AlignedMalloc(size, inner::ALIGN_PAGE_SIZE));
+        AlignedMalloc(size, inner::getPageSize()));
   }
   virtual void free(uint32_t *p) { AlignedFree(p); }
   virtual ~AllocatorAArch64() {}
@@ -60,7 +60,7 @@ class MmapAllocatorAArch64 : AllocatorAArch64 {
 
 public:
   uint32_t *alloc(size_t size) {
-    const size_t alignedSizeM1 = inner::ALIGN_PAGE_SIZE - 1;
+    const size_t alignedSizeM1 = inner::getPageSize() - 1;
     size = (size + alignedSizeM1) & ~alignedSizeM1;
 #ifdef MAP_ANONYMOUS
     const int mode = MAP_PRIVATE | MAP_ANONYMOUS;
@@ -327,7 +327,7 @@ static inline bool protect(const void *addr, size_t size, int protectMode) {
   DWORD oldProtect;
   return VirtualProtect(const_cast<void *>(addr), size, mode, &oldProtect) != 0;
 #elif defined(__GNUC__)
-    size_t pageSize = sysconf(_SC_PAGESIZE);
+    size_t pageSize = inner::getPageSize();
     size_t iaddr = reinterpret_cast<size_t>(addr);
     size_t roundAddr = iaddr & ~(pageSize - static_cast<size_t>(1));
 

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -5528,7 +5528,7 @@ public:
     if (x < 4 || (x % 4))
       throw Error(ERR_BAD_ALIGN);
 
-    if (isAutoGrow() && x > inner::ALIGN_PAGE_SIZE)
+    if (isAutoGrow() && x > inner::getPageSize())
       fprintf(stderr, "warning:autoGrow mode does not support %d align\n",
               (int)x);
 

--- a/xbyak_aarch64/xbyak_aarch64_inner.h
+++ b/xbyak_aarch64/xbyak_aarch64_inner.h
@@ -22,7 +22,15 @@ enum {
 
 namespace inner {
 
-static const size_t ALIGN_PAGE_SIZE = 4096;
+inline size_t getPageSize()
+{
+#ifdef __GNUC__
+  static const size_t pageSize = sysconf(_SC_PAGESIZE);
+#else
+  static const size_t pageSize = 4096;
+#endif
+  return pageSize;
+}
 
 inline bool IsInDisp8(uint32_t x) { return 0xFFFFFF80 <= x || x <= 0x7F; }
 inline bool IsInInt32(uint64_t x) {


### PR DESCRIPTION
The current version can't deal with pageSize = 65536, then use getPageSize() instead of static const size(4096).