### PR TITLE
build: add build "-std=c++11" to build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all=lib/libxbyak_aarch64.a
-CFLAGS=-O3 -DNDEBUG -I ./xbyak_aarch64
+CFLAGS=-std=c++11 -O3 -DNDEBUG -I ./xbyak_aarch64
 
 obj/%.o: src/%.cpp
 	$(CXX) $(CFLAGS) -c $< -o $@ -MMD -MP -MF $(@:.o=.d)


### PR DESCRIPTION
Without "-std=c++11", gcc 5.4.0 (Ubuntu-16.04) fails to build.