### PR TITLE
`ready()` should be after appending codes, before `genCode()`

### DIFF
--- a/sample/add2.cpp
+++ b/sample/add2.cpp
@@ -34,9 +34,9 @@ public:
 int main(int argc, char *argv[]) {
   (void)argc; // -Wunused-parameter
   Generator gen;
-  gen.ready();
   gen.generate(atoi(argv[1]), atoi(argv[2]));
   gen.postamble();
+  gen.ready();
 
   auto f = gen.getCode<int (*)(int, int)>();
   std::cout << f(atoi(argv[1]), atoi(argv[2])) << std::endl;


### PR DESCRIPTION
According to the comments in the code and README, the `ready()` function seems designed to be called after appending a sequence of instructions, before calling `getCode()`.