### PR TITLE
Fix some in Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-all=lib/libxbyak_aarch64.a
 CFLAGS=-std=c++11 -O3 -DNDEBUG -I ./xbyak_aarch64
 
-obj/%.o: src/%.cpp
+all: lib/libxbyak_aarch64.a
+
+obj/xbyak_aarch64_impl.o: src/xbyak_aarch64_impl.cpp src/xbyak_aarch64_impl.h src/xbyak_aarch64_mnemonic.h
 	$(CXX) $(CFLAGS) -c $< -o $@ -MMD -MP -MF $(@:.o=.d)
 
 lib/libxbyak_aarch64.a: obj/xbyak_aarch64_impl.o

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,15 +1,15 @@
 SRC=add.cpp add2.cpp label.cpp direct_write.cpp dump.cpp
 OBJ=$(SRC:.cpp=.o)
-EXE=$(SRC:.cpp=.exe)
+EXE=$(SRC:.cpp=)
 all: $(EXE)
 
 LDFLAGS=-L ../lib -lxbyak_aarch64
-CFLAGS=-g -DNDEBUG -Wall -Wextra -I ../xbyak_aarch64
+CFLAGS=-std=c++11 -O3 -DNDEBUG -Wall -Wextra -I ../xbyak_aarch64
 
 %.o: %.cpp
 	$(CXX) -c $< -o $@ $(CFLAGS)
 
-%.exe: %.o
+%: %.o
 	$(CXX) $< -o $@ $(LDFLAGS)
 
 clean:

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ all: $(TARGET)
 CXX=g++
 CFLAGS_WARN=-Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align -Wwrite-strings -Wfloat-equal -Wpointer-arith -Wunused-function
 
-CFLAGS=-O2 -fomit-frame-pointer -Wall -fno-operator-names -I../ -I./ $(CFLAGS_WARN) ../lib/libxbyak_aarch64.a #-std=c++0x
+CFLAGS=-std=c++11 -O3 -fomit-frame-pointer -Wall -fno-operator-names -I../xbyak_aarch64/ -I./ $(CFLAGS_WARN) ../lib/libxbyak_aarch64.a
 make_nm: make_nm.cpp $(XBYAK_INC)
 	$(CXX) $(CFLAGS) make_nm.cpp -o $@
 make_nm_load_store: make_nm_load_store.cpp $(XBYAK_INC)


### PR DESCRIPTION
Proposing some small fixes in Makefiles:

* added `-std=c++11` for compilers whose default is older than that.
* also, defaulted to use `-O3`.
* fixed include path to `xbyak_aarch64.h` in `test/`.
* added `all` target for examples.
* removed `.exe` prefix from the example executables.

I tested these fixes only on my arm mac mini w/ Apple clang 12.0. So some might conflict environments that I haven't took into consideration. So I'd appreciate you to pick only those that are consistent with the environments that are already in use.