### PR TITLE
Support macOS Big Sur (Apple M1 chips)

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -17,7 +17,6 @@
 
 #include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
-#include <pthread.h>
 
 static const size_t CSIZE = sizeof(uint32_t);
 

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -17,6 +17,7 @@
 
 #include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
+#include <pthread.h>
 
 static const size_t CSIZE = sizeof(uint32_t);
 
@@ -74,9 +75,9 @@ public:
     //
     // (Note: We assume the OS is Big Sur (11.0) or later. For supporting earlier ones,
     // the xbyak source code would be helpful: https://github.com/herumi/xbyak/blob/master/xbyak/xbyak.h
-    void *p = mmap(NULL, size, mode | MAP_JIT, mode, -1, 0);
+    void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode | MAP_JIT, -1, 0);
 #else
-    void *p = mmap(NULL, size, mode, mode, -1, 0);
+    void *p = mmap(NULL, size, PROT_READ | PROT_WRITE, mode, -1, 0);
 #endif
 
     if (p == MAP_FAILED)

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -65,7 +65,7 @@ public:
 #ifdef __APPLE__
     // On macOS environments, we have to do the following three steps to do well with the security features:
     // 1. allocate memory using mmap with MAP_JIT flag.
-    // 2. remove threadwise executable (E) flag make the memory writable.
+    // 2. remove executable (E) flag from the region to make it writable.
     // 3. restore the E flag to make the memory runnable.
     // (because the mmap'd memory can't be made executable without MAP_JIT, and the OS prohibits
     // any store operation to executable regions.)

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -79,11 +79,11 @@ public:
         "illegal shift-mode paramater",
         "illegal extend-mode parameter",
         "illegal condition parameter",
-        "illegal type",
         "illegal barrier option",
         "illegal const parameter (range error)",
         "illegal const parameter (unavailable error)",
         "illegal const parameter (condition error)",
+        "illegal type"
     };
     if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
       msg_ = "bad err num";

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -41,6 +41,7 @@ enum {
   ERR_ILLEGAL_CONST_RANGE,       // use at CodeGenerator
   ERR_ILLEGAL_CONST_VALUE,       // use at CodeGenerator
   ERR_ILLEGAL_CONST_COND,        // use at CodeGenerator
+  ERR_ILLEGAL_PROTECT_MODE,      // use at CodeGenerator
   ERR_ILLEGAL_TYPE,
   ERR_BAD_ALIGN,
   ERR_BAD_ADDRESSING,
@@ -83,7 +84,12 @@ public:
         "illegal const parameter (range error)",
         "illegal const parameter (unavailable error)",
         "illegal const parameter (condition error)",
-        "illegal type"
+        "illegal protect mode (RWX prohibited on this environment)",
+        "illegal type",
+        "bad alignment",
+        "bad addressing",
+        "bad scaling",
+        "munmap failed"
     };
     if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
       msg_ = "bad err num";

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -1048,13 +1048,23 @@ public:
      mode.
           It is not necessary for the other mode if hasUndefinedLabel() is true.
   */
+#ifdef __APPLE__
+  void ready(ProtectMode mode = PROTECT_RE) {
+    // macOS requires executable memory to be non-writable
+    // so the mode other than RE is just an error.
+    if (mode == PROTECT_RWE)
+      throw Error(ERR_ILLEGAL_PROTECT_MODE);
+#else
   void ready(ProtectMode mode = PROTECT_RWE) {
+    // RWE is the default behavior on non-macOS environments.
+#endif
     if (hasUndefinedLabel())
       throw Error(ERR_LABEL_IS_NOT_FOUND);
     if (isAutoGrow()) {
       calcJmpAddress();
-      if (useProtect())
-        setProtectMode(mode);
+    }
+    if (useProtect()) {
+      setProtectMode(mode);
     }
     clearCache(const_cast<uint8_t *>(getCode()), const_cast<uint8_t *>(getCurr()));
   }


### PR DESCRIPTION
Added initial support for macOS. The OS requires the code memory to be exclusively writable or executable for security reason. So I added lines to make memory block to be non-executable right after the allocation, and non-writable (and executable) when `ready()` is called.

Also overriding `useProtect()` function, and `ready()` with `PROTECT_RWE` are prohibited in macOS envs so that the conditions can't be violated.

This PR depends on another PR by me: https://github.com/fujitsu/xbyak_aarch64/pull/43.