### PR TITLE
add <asm/hwcap.h> for Ubuntu 16.04

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -21,6 +21,15 @@
 #ifdef __linux__
 #include <sys/auxv.h>
 #include <sys/prctl.h>
+
+/* In old Linux such as Ubuntu 16.04, HWCAP_ATOMICS, HWCAP_FP, HWCAP_ASIMD
+   can not be found in <bits/hwcap.h> which is included from <sys/auxv.h>.
+   Xbyak_aarch64 uses <asm/hwcap.h> as an alternative.
+ */
+#ifndef HWCAP_FP
+#include <asm/hwcap.h>
+#endif
+
 #elif defined(__APPLE__)
 #include <sys/sysctl.h>
 #endif


### PR DESCRIPTION
Because older Linux such as Ubuntu 16.04 has no definition of `HWCAP_ATOMICS`, `HWCAP_FP`, `HWCAP_ASIMD` in `<bits/hwcap.h>` which is included from `<sys/auxv.h>`. `<asm/hwcap.h>`, which defines the same `HWCAP_ATOMICS`, `HWCAP_FP`, and `HWCAP_ASIMD`, is used as an alternative.
