### PR TITLE
use 'defined' for macro

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -758,7 +758,7 @@ public:
 #ifdef _WIN32
     (void)begin;
     (void)end;
-#elif __APPLE__
+#elif defined(__APPLE__)
     sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
 #else
     __builtin___clear_cache((char *)begin, (char *)end);


### PR DESCRIPTION
`#elif defined` is better than `#elif`