### PR TITLE
fix a missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,6 @@ c.setProtectModeRE();
 
 
 Call `readyRE()` instead of `ready()` when using `AutoGrow` mode.
-See [protect-re.cpp](sample/protect-re.cpp).
 
 ## How to pass arguments to JIT generated function
 To be written...


### PR DESCRIPTION
The link to `sample/protect-re.cpp` is missing. 
Please consider removing the following sentence.

> See [protect-re.cpp](sample/protect-re.cpp).