### PR TITLE
fix cbz/cbnz/tbz/tbnz

### DIFF
--- a/src/xbyak_aarch64_impl.h
+++ b/src/xbyak_aarch64_impl.h
@@ -638,7 +638,7 @@ uint32_t CodeGenerator::CompareBrEnc(uint32_t op, const RReg &rt, int64_t labelO
 }
 
 void CodeGenerator::CompareBr(uint32_t op, const RReg &rt, const Label &label) {
-  auto encFunc = [=, &op](int64_t labelOffset) { return CompareBrEnc(op, rt, labelOffset); };
+  auto encFunc = [=](int64_t labelOffset) { return CompareBrEnc(op, rt, labelOffset); };
   JmpLabel jmpL = JmpLabel(encFunc, size_);
   uint32_t code = CompareBrEnc(op, rt, genLabelOffset(label, jmpL));
   dd(code);
@@ -665,7 +665,7 @@ uint32_t CodeGenerator::TestBrEnc(uint32_t op, const RReg &rt, uint32_t imm, int
 }
 
 void CodeGenerator::TestBr(uint32_t op, const RReg &rt, uint32_t imm, const Label &label) {
-  auto encFunc = [&, op, rt, imm](int64_t labelOffset) { return TestBrEnc(op, rt, imm, labelOffset); };
+  auto encFunc = [=](int64_t labelOffset) { return TestBrEnc(op, rt, imm, labelOffset); };
   JmpLabel jmpL = JmpLabel(encFunc, size_);
   uint32_t code = TestBrEnc(op, rt, imm, genLabelOffset(label, jmpL));
   dd(code);


### PR DESCRIPTION
C++ reference should be used for the following case, otherwise `L(Done)` uses a reference to an object that no longer exists.

```C++
Label Done;
cbz(XReg(0), Done);
L(Done);
```