### PR TITLE
Refactor util

### DIFF
--- a/src/err_impl.h
+++ b/src/err_impl.h
@@ -1,0 +1,43 @@
+#pragma once
+
+Error::Error(int err) : err_(err), msg_("") {
+  if (err_ <= 0)
+    return;
+  fprintf(stderr, "bad err=%d in Xbyak::Error\n", err_);
+  static const char *tbl[32] = {
+      "none",
+      "code is too big",
+      "label is redefined",
+      "label is too far",
+      "label is not found",
+      "bad parameter",
+      "can't protect",
+      "offset is too big",
+      "can't alloc",
+      "label is not set by L()",
+      "label is already set by L()",
+      "internal error",
+      "illegal register index (can not encoding register index)",
+      "illegal register element index (can not encoding element index)",
+      "illegal predicate register type",
+      "illegal immediate parameter (range error)",
+      "illegal immediate parameter (unavailable value error)",
+      "illegal immediate parameter (condition error)",
+      "illegal shift-mode paramater",
+      "illegal extend-mode parameter",
+      "illegal condition parameter",
+      "illegal barrier option",
+      "illegal const parameter (range error)",
+      "illegal const parameter (unavailable error)",
+      "illegal const parameter (condition error)",
+      "illegal type",
+      "bad align",
+      "bad addressing",
+      "bad scale",
+  };
+  if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
+    msg_ = "bad err num";
+  } else {
+    msg_ = tbl[err_];
+  }
+}

--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -42,6 +42,7 @@
 
 #elif defined(__APPLE__)
 #include <sys/sysctl.h>
+#include <unistd.h>
 
 constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
 constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
@@ -117,6 +118,7 @@ void Cpu::setCacheHierarchy() {
      */
     /* If `sysconf` returns zero as cache sizes, 32KiB, 1MiB, 0 and 0 is set as
        1st, 2nd, 3rd and 4th level cache sizes. 2nd cahce is assumed as sharing cache. */
+#ifdef __linux__
     coresSharingDataCache_[0] = getCacheSize(_SC_LEVEL1_DCACHE_SIZE, 1024 * 32, 1);
     coresSharingDataCache_[1] = getCacheSize(_SC_LEVEL2_CACHE_SIZE, 1024 * 1024, 1);
     coresSharingDataCache_[2] = getCacheSize(_SC_LEVEL3_CACHE_SIZE, 0, 1);
@@ -126,6 +128,17 @@ void Cpu::setCacheHierarchy() {
     dataCacheSize_[1] = getCacheSize(_SC_LEVEL2_CACHE_SIZE, 1024 * 1024, 8);
     dataCacheSize_[2] = getCacheSize(_SC_LEVEL3_CACHE_SIZE, 0, 1);
     dataCacheSize_[3] = getCacheSize(_SC_LEVEL4_CACHE_SIZE, 0, 1);
+#elif defined(__APPLE__)
+    coresSharingDataCache_[0] = getCacheSize(HW_L1DCACHESIZE, 1024 * 32, 1);
+    coresSharingDataCache_[1] = getCacheSize(HW_L2CACHESIZE, 1024 * 1024, 1);
+    coresSharingDataCache_[2] = getCacheSize(HW_L3CACHESIZE, 0, 1);
+    coresSharingDataCache_[3] = 0;
+
+    dataCacheSize_[0] = getCacheSize(HW_L1DCACHESIZE, 1024 * 32, 1);
+    dataCacheSize_[1] = getCacheSize(HW_L2CACHESIZE, 1024 * 1024, 8);
+    dataCacheSize_[2] = getCacheSize(HW_L3CACHESIZE, 0, 1);
+    dataCacheSize_[3] = 0;
+#endif
   }
 }
 
@@ -229,6 +242,7 @@ int Cpu::getFilePathMaxTailNumPlus1(const char *path) {
 
   return retVal;
 #else
+  (void)path;
   return 0;
 #endif
 }

--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -15,6 +15,31 @@
  *******************************************************************************/
 #include "xbyak_aarch64_util.h"
 
+#include <dirent.h>
+#include <regex.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef __linux__
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <unistd.h>
+
+/* In old Linux such as Ubuntu 16.04, HWCAP_ATOMICS, HWCAP_FP, HWCAP_ASIMD
+   can not be found in <bits/hwcap.h> which is included from <sys/auxv.h>.
+   Xbyak_aarch64 uses <asm/hwcap.h> as an alternative.
+ */
+#ifndef HWCAP_FP
+#include <asm/hwcap.h>
+#endif
+
+#elif defined(__APPLE__)
+#include <sys/sysctl.h>
+#endif
+
+
 namespace Xbyak_aarch64 {
 namespace util {
 

--- a/src/xbyak_aarch64_impl.cpp
+++ b/src/xbyak_aarch64_impl.cpp
@@ -16,9 +16,11 @@
 #define XBYAK_AARCH64_MAKE_INSTANCE
 #include "xbyak_aarch64.h"
 #include <memory.h>
+#include <stdio.h>
 
 namespace Xbyak_aarch64 {
 
+#include "err_impl.h"
 #include "xbyak_aarch64_impl.h"
 #include "xbyak_aarch64_mnemonic.h"
 

--- a/xbyak_aarch64/xbyak_aarch64.h
+++ b/xbyak_aarch64/xbyak_aarch64.h
@@ -66,6 +66,8 @@
 #endif
 #endif
 
+#include "xbyak_aarch64_err.h"
+
 namespace Xbyak_aarch64 {
 const uint64_t SP_IDX = 31;
 const uint64_t NUM_VREG_BYTES = 16;

--- a/xbyak_aarch64/xbyak_aarch64_adr.h
+++ b/xbyak_aarch64/xbyak_aarch64_adr.h
@@ -14,8 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_reg.h"
 
 enum ShMod { LSL = 0, LSR = 1, ASR = 2, ROR = 3, MSL = 4, NONE = 5 };

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -164,8 +164,10 @@ public:
     PROTECT_RE = 2   // read/exec
   };
   explicit CodeArray(size_t maxSize, void *userPtr = 0, Allocator *allocator = 0)
-      : type_(userPtr == AutoGrow ? AUTO_GROW : (userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF : USER_BUF), alloc_(allocator ? allocator : (Allocator *)&defaultAllocator_), maxSize_(maxSize / CSIZE),
-        top_(type_ == USER_BUF ? reinterpret_cast<uint32_t *>(userPtr) : alloc_->alloc((std::max<size_t>)(maxSize, CSIZE))), size_(0), isCalledCalcJmpAddress_(false) {
+      : type_(userPtr == AutoGrow                              ? AUTO_GROW
+              : (userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF
+                                                               : USER_BUF),
+        alloc_(allocator ? allocator : (Allocator *)&defaultAllocator_), maxSize_(maxSize / CSIZE), top_(type_ == USER_BUF ? reinterpret_cast<uint32_t *>(userPtr) : alloc_->alloc((std::max<size_t>)(maxSize, CSIZE))), size_(0), isCalledCalcJmpAddress_(false) {
     if (maxSize_ > 0 && top_ == 0)
       throw Error(ERR_CANT_ALLOC);
     if ((type_ == ALLOC_BUF && userPtr != DontSetProtectRWE && useProtect()) && !setProtectMode(PROTECT_RWE, false)) {

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -15,7 +15,6 @@
  * limitations under the License.
  *******************************************************************************/
 
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
 
 static const size_t CSIZE = sizeof(uint32_t);

--- a/xbyak_aarch64/xbyak_aarch64_code_array.h
+++ b/xbyak_aarch64/xbyak_aarch64_code_array.h
@@ -164,10 +164,8 @@ public:
     PROTECT_RE = 2   // read/exec
   };
   explicit CodeArray(size_t maxSize, void *userPtr = 0, Allocator *allocator = 0)
-      : type_(userPtr == AutoGrow                              ? AUTO_GROW
-              : (userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF
-                                                               : USER_BUF),
-        alloc_(allocator ? allocator : (Allocator *)&defaultAllocator_), maxSize_(maxSize / CSIZE), top_(type_ == USER_BUF ? reinterpret_cast<uint32_t *>(userPtr) : alloc_->alloc((std::max<size_t>)(maxSize, CSIZE))), size_(0), isCalledCalcJmpAddress_(false) {
+      : type_(userPtr == AutoGrow ? AUTO_GROW : (userPtr == 0 || userPtr == DontSetProtectRWE) ? ALLOC_BUF : USER_BUF), alloc_(allocator ? allocator : (Allocator *)&defaultAllocator_), maxSize_(maxSize / CSIZE),
+        top_(type_ == USER_BUF ? reinterpret_cast<uint32_t *>(userPtr) : alloc_->alloc((std::max<size_t>)(maxSize, CSIZE))), size_(0), isCalledCalcJmpAddress_(false) {
     if (maxSize_ > 0 && top_ == 0)
       throw Error(ERR_CANT_ALLOC);
     if ((type_ == ALLOC_BUF && userPtr != DontSetProtectRWE && useProtect()) && !setProtectMode(PROTECT_RWE, false)) {

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -54,47 +54,7 @@ class Error : public std::exception {
   const char *msg_;
 
 public:
-  explicit Error(int err) : err_(err), msg_("") {
-    if (err_ <= 0)
-      return;
-    fprintf(stderr, "bad err=%d in Xbyak::Error\n", err_);
-    static const char *tbl[32] = {
-        "none",
-        "code is too big",
-        "label is redefined",
-        "label is too far",
-        "label is not found",
-        "bad parameter",
-        "can't protect",
-        "offset is too big",
-        "can't alloc",
-        "label is not set by L()",
-        "label is already set by L()",
-        "internal error",
-        "illegal register index (can not encoding register index)",
-        "illegal register element index (can not encoding element index)",
-        "illegal predicate register type",
-        "illegal immediate parameter (range error)",
-        "illegal immediate parameter (unavailable value error)",
-        "illegal immediate parameter (condition error)",
-        "illegal shift-mode paramater",
-        "illegal extend-mode parameter",
-        "illegal condition parameter",
-        "illegal barrier option",
-        "illegal const parameter (range error)",
-        "illegal const parameter (unavailable error)",
-        "illegal const parameter (condition error)",
-        "illegal type",
-        "bad align",
-        "bad addressing",
-        "bad scale",
-    };
-    if ((size_t)err_ >= sizeof(tbl) / sizeof(tbl[0])) {
-      msg_ = "bad err num";
-    } else {
-      msg_ = tbl[err_];
-    }
-  }
+  explicit Error(int err);
   operator int() const { return err_; }
   const char *what() const throw() { return msg_; }
 };

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -16,6 +16,8 @@
  *******************************************************************************/
 #include <exception>
 
+namespace Xbyak_aarch64 {
+
 enum {
   ERR_NONE = 0,
   ERR_CODE_IS_TOO_BIG,           // use at CodeArray
@@ -60,3 +62,5 @@ public:
 };
 
 inline const char *ConvertErrorToString(const Error &err) { return err.what(); }
+
+} // namespace Xbyak_aarch64

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -20,7 +20,6 @@
 
 #include "xbyak_aarch64_adr.h"
 #include "xbyak_aarch64_code_array.h"
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_label.h"
 #include "xbyak_aarch64_reg.h"
 

--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -19,7 +19,6 @@
 #define _XBYAK_AARCH64_LABEL_
 
 #include "xbyak_aarch64_code_array.h"
-#include "xbyak_aarch64_err.h"
 #include "xbyak_aarch64_inner.h"
 
 struct JmpLabel {

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 
+
 namespace Xbyak_aarch64 {
 namespace util {
 typedef uint64_t Type;

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -17,30 +17,6 @@
 #ifndef XBYAK_AARCH64_UTIL_H_
 #define XBYAK_AARCH64_UTIL_H_
 
-#include <dirent.h>
-#include <regex.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-#ifdef __linux__
-#include <sys/auxv.h>
-#include <sys/prctl.h>
-#include <unistd.h>
-
-/* In old Linux such as Ubuntu 16.04, HWCAP_ATOMICS, HWCAP_FP, HWCAP_ASIMD
-   can not be found in <bits/hwcap.h> which is included from <sys/auxv.h>.
-   Xbyak_aarch64 uses <asm/hwcap.h> as an alternative.
- */
-#ifndef HWCAP_FP
-#include <asm/hwcap.h>
-#endif
-
-#elif defined(__APPLE__)
-#include <sys/sysctl.h>
-#endif
-
 #include "xbyak_aarch64_err.h"
 
 #define XBYAK_AARCH64_MIDR_EL1(I, V, A, P, R) ((I << 24) | (V << 20) | (A << 16) | (P << 4) | (R << 0))

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -19,7 +19,6 @@
 
 #include <stdint.h>
 
-
 namespace Xbyak_aarch64 {
 namespace util {
 typedef uint64_t Type;

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -17,12 +17,8 @@
 #ifndef XBYAK_AARCH64_UTIL_H_
 #define XBYAK_AARCH64_UTIL_H_
 
-#include "xbyak_aarch64_err.h"
+#include <stdint.h>
 
-#define XBYAK_AARCH64_MIDR_EL1(I, V, A, P, R) ((I << 24) | (V << 20) | (A << 16) | (P << 4) | (R << 0))
-#define XBYAK_AARCH64_PATH_NODES "/sys/devices/system/node/node"
-#define XBYAK_AARCH64_PATH_CORES "/sys/devices/system/node/node0/cpu"
-#define XBYAK_AARCH64_READ_SYSREG(var, ID) asm("mrs %0, " #ID : "=r"(var));
 
 namespace Xbyak_aarch64 {
 namespace util {
@@ -66,27 +62,6 @@ struct cacheInfo_t {
   uint32_t dataCacheSize[maxNumberCacheLevel];
 };
 
-#ifdef __APPLE__
-constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
-constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
-constexpr char hw_opt_neon[] = "hw.optional.neon";
-#endif
-
-const struct implementer_t implementers[] = {{0x00, "Reserved for software use"},
-                                             {0xC0, "Ampere Computing"},
-                                             {0x41, "Arm Limited"},
-                                             {0x42, "Broadcom Corporation"},
-                                             {0x43, "Cavium Inc."},
-                                             {0x44, "Digital Equipment Corporation"},
-                                             {0x46, "Fujitsu Ltd."},
-                                             {0x49, "Infineon Technologies AG"},
-                                             {0x4D, "Motorola or Freescale Semiconductor Inc."},
-                                             {0x4E, "NVIDIA Corporation"},
-                                             {0x50, "Applied Micro Circuits Corporation"},
-                                             {0x51, "Qualcomm Inc."},
-                                             {0x56, "Marvell International Ltd."},
-                                             {0x69, "Intel Corporation"}};
-
 /**
    CPU detection class
 */
@@ -95,11 +70,6 @@ class Cpu {
   sveLen_t sveLen_;
 
 private:
-  const struct cacheInfo_t cacheInfoDict[2] = {
-      {/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x1, 0xf, 0x1, 0x0), 2, 1, {1024 * 64, 1024 * 1024 * 8 * 4, 0, 0}},
-      {/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x2, 0xf, 0x1, 0x0), 2, 1, {1024 * 64, 1024 * 1024 * 8 * 4, 0, 0}},
-  };
-
   uint32_t coresSharingDataCache_[maxNumberCacheLevel];
   uint32_t dataCacheSize_[maxNumberCacheLevel];
   uint32_t dataCacheLevel_;


### PR DESCRIPTION
1. move OS-depended code from xbyak_aarch64_util.h to src/util_impl.cpp
2. support macOS
3. `<exception>` should be included from global namespace