### PR TITLE
Support ARM64 Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,11 @@ option(
 	"Build xbyak_aarch64 samples"
 	OFF
 )
-option(
-	TEST
-	"Build xbyak_aarch64 tests"
-	OFF
-)
+#option(
+#	TEST
+#	"Build xbyak_aarch64 tests"
+#	OFF
+#)
 
 if(NOT DEFINED CMAKE_BUILD_TYPE)
 	set(CMAKE_BUILD_TYPE "Release")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,95 @@
+cmake_minimum_required (VERSION 3.8)
+
+project(xbyak_aarch64
+	VERSION 1.0.0
+	LANGUAGES CXX)
+
+option(
+	SAMPLE
+	"Build xbyak_aarch64 samples"
+	OFF
+)
+option(
+	TEST
+	"Build xbyak_aarch64 tests"
+	OFF
+)
+
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "Release")
+endif()
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_library(xbyak_aarch64 STATIC src/xbyak_aarch64_impl.cpp src/util_impl.cpp)
+target_include_directories(xbyak_aarch64 PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/xbyak_aarch64/>
+	$<INSTALL_INTERFACE:$CMAKE_INSTALL_DIR/include>)
+set_target_properties(xbyak_aarch64 PROPERTIES
+	POSITION_INDEPENDENT_CODE ON)
+
+if(MSVC)
+	if(MCL_MSVC_RUNTIME_DLL)
+		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /MD /Oy /Ox /EHsc /GS- /Zi /DNDEBUG")
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} /MDd")
+	else()
+		set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /MT /Oy /Ox /EHsc /GS- /Zi /DNDEBUG")
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS} /MTd")
+	endif()
+
+	target_compile_definitions(xbyak_aarch64 PUBLIC NOMINMAX)
+	set(MCL_COMPILE_OPTIONS /W4)
+	target_compile_options(xbyak_aarch64 PRIVATE ${MCL_COMPILE_OPTIONS})
+else()
+	# Set compiler flags for warnings
+	set(MCL_COMPILE_OPTIONS -Wall -Wextra -Wformat=2 -Wcast-qual -Wcast-align
+		-Wwrite-strings -Wfloat-equal -Wpointer-arith -DNDEBUG -O3 -fPIC)
+
+	target_compile_options(xbyak_aarch64 PRIVATE ${MCL_COMPILE_OPTIONS})
+	set_target_properties(xbyak_aarch64 PROPERTIES
+		CXX_STANDARD 11
+		CXX_STANDARD_REQUIRED YES
+		CXX_EXTENSIONS NO)
+	target_compile_features(xbyak_aarch64 PUBLIC cxx_std_11)
+endif()
+
+install(TARGETS xbyak_aarch64
+	EXPORT xbyak_aarch64Targets
+	LIBRARY DESTINATION lib
+	ARCHIVE DESTINATION lib
+)
+
+install(DIRECTORY include/xbyak_aarch64
+	DESTINATION include
+	FILES_MATCHING PATTERN "*.h"
+)
+
+install(EXPORT xbyak_aarch64Targets
+	FILE xbyak_aarch64Targets.cmake
+	NAMESPACE xbyak_aarch64::
+	DESTINATION lib/cmake/xbyak_aarch64)
+
+# support local build-tree export to allow import from external projects
+export(EXPORT xbyak_aarch64Targets
+	FILE xbyak_aarch64Targets.cmake
+	NAMESPACE xbyak_aarch64::)
+set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
+export(PACKAGE xbyak_aarch64 )
+
+
+# Tests
+if(TEST)
+	enable_testing()
+	add_subdirectory(test)
+endif()
+
+if(SAMPLE)
+	# sample code
+	add_subdirectory(sample)
+endif()

--- a/README.md
+++ b/README.md
@@ -82,6 +82,16 @@ make
 ```
 makes `lib/libxbyak_aarch64.a`.
 
+## How to use cmake
+
+on Windows ARM64
+```
+mkdir build
+cd build
+cmake .. -A arm64
+msbuild xbyak_aarch64.sln /p:Configuration=Release
+```
+
 ## How to use Xbyak_aarch64
 
 Inherit `Xbyak::CodeGenerator` class and make the class method.
@@ -179,7 +189,7 @@ add(w0, w1, w2);                <--- Output is same JIT code of (1)
 
 ##### SIMD/Floating point registers as scalar registers
 
-As SIMD/Floating point registers with scalar use, 
+As SIMD/Floating point registers with scalar use,
 the following table shows example of mnemonic functions' arguments ("Instance name" column).
 
 |Instance name|C++ class name|Remarks|
@@ -203,7 +213,7 @@ mov(dstReg, v0.b[5]);   <--- Output is same JIT code of (1)
 
 #### SIMD/Floating point registers as vector registers
 
-As SIMD/Floating point registers with vector use, 
+As SIMD/Floating point registers with vector use,
 the following table shows example of mnemonic functions' arguments ("Instance name" column).
 
 |Instance name|C++ class name|Remarks|
@@ -230,7 +240,7 @@ mov(dstReg, srcReg);   <--- Output is same JIT code of (1)
 
 #### Element of SIMD/Floating point registers
 
-As SIMD/Floating point registers with element-wise use, 
+As SIMD/Floating point registers with element-wise use,
 the following table shows example of mnemonic functions' arguments ("Instance name" column).
 
 |Instance name|C++ class name|Remarks|
@@ -316,7 +326,7 @@ ld4(hoge, ptr(x0));         <--- Output is same JIT code of (1)
 ```
 
 ### SVE registers as vector registers
-AS SVE registers, 
+AS SVE registers,
 the following table shows example of mnemonic functions' arguments ("Instance name" column).
 
 
@@ -342,7 +352,7 @@ add(dstReg, z1.b, z2.b);    <--- Output is same JIT code of (1)
 
 ### Element of SVE registers
 
-As SVE registers with element-wise use, 
+As SVE registers with element-wise use,
 the following table shows example of mnemonic functions' arguments ("Instance name" column).
 
 |Instance name|C++ class name|Remarks|
@@ -473,7 +483,7 @@ such as, "10", "-128", "0xFF", "1<<32", "3.5", etc.
 Please care for range of values.
 For example, "ADD (immediate)" instruction can receive signed 12-bit value
 so that you have to ensure that the value passed to mnemonic function is inside the range.
-Mnemonic functions of Xbyak_aarch64 checks immediate values at runtime, 
+Mnemonic functions of Xbyak_aarch64 checks immediate values at runtime,
 and throws exception if it detects range over.
 
 ```
@@ -500,7 +510,7 @@ void gen_Summation_From_One_To_Parameter_Func(unsigned int N) {
         printf("This function supports less than 2048.\n");
     }
 }
-```    
+```
 
 #### Symbols
 Some instructions of the AArch64 instruction set are used with sybols such as **"UXTW", "LSL", "SXTW", "SXTX", "MUL VL"**, etc.
@@ -515,7 +525,7 @@ grep LSL sample/mnemonic_syntax/*
 #### Addressing
 The AArch64 instruction set has various addressing modes such as "No offset", "Post-index", "Pre-index", "Signed offset", "Unsigned offset".
 Please use "ptr()", "pre_ptr()", "post_ptr()" functions to specify which addressing mode you want to use.
-Please "grep" the functions, for example 
+Please "grep" the functions, for example
 ```
 grep -w ptr sample/mnemonic_syntax/*
 ```
@@ -524,7 +534,7 @@ grep -w ptr sample/mnemonic_syntax/*
 
 |Use example|corresponding assembler syntax|Remarks|
 |----|----|----|
-|ldr(x0, ptr(x1, x7))|ldr x0, [x1, x7]|Register offset| 
+|ldr(x0, ptr(x1, x7))|ldr x0, [x1, x7]|Register offset|
 |str(w0, ptr(x7, w8, UXTW, 2))|str w0, [x7, w8, UXTW 2]|Register offset with shift amount|
 |ldr(w0, post_ptr(x5, -16))|ldr w0, [x5], -16|Post-index|
 |ldrb(w16, pre_ptr(x5, 127))|ldrb w16, [x5, 127]!|Pre-index|
@@ -537,15 +547,15 @@ The following example shows how to use "Label".
 
 ```
 Label L1;           // (1), instance of Label class
- 
-mov(w4, w0); 
-mov(w3, 0); 
-mov(w0, 0); 
+
+mov(w4, w0);
+mov(w3, 0);
+mov(w0, 0);
 L(L1);              // (2), "L" function registers JIT code address of this position to label L1.
-add(w0, w0, w4); 
-add(w3, w3, 1); 
-cmp(w2, w3); 
-ccmp(w1, w3, 4, NE); 
+add(w0, w0, w4);
+add(w3, w3, 1);
+cmp(w2, w3);
+ccmp(w1, w3, 4, NE);
 bgt(L1);            // (3), set destination of branch instruction to the address stored in L1.
 ```
 
@@ -556,17 +566,17 @@ bgt(L1);            // (3), set destination of branch instruction to the address
 You can copy the address stored in "Label" instance by using `assignL` function.
 
 ```
-Label L1,L2,L3; 
+Label L1,L2,L3;
 ....
 L(L1);               // JIT code address of this position is stored to L1.
 ....
 L(L2);               // JIT code address of this position is stored to L1.
 ....
-if (flag) { 
+if (flag) {
 assignL(L3,L1);      // The address stored in L1 is copied to L3.
-} else { 
+} else {
 assignL(L3,L2);      // The address stored in L1 is copied to L3.
-} 
+}
 b(L3);               // If flag == true, branch destination is L1, otherwise L2.
 ```
 

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Samples
+set(TARGET add add2 bf label)
+foreach(src IN ITEMS ${TARGET})
+	add_executable(${src} ${src}.cpp)
+	target_link_libraries(${src} PRIVATE xbyak_aarch64)
+	set_target_properties(${src} PROPERTIES
+		CXX_STANDARD 11
+		CXX_STANDARD_REQUIRED YES
+	CXX_EXTENSIONS NO)
+endforeach()

--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Samples
-set(TARGET add add2 bf label)
+set(TARGET add add2 bf label cpuinfo)
 foreach(src IN ITEMS ${TARGET})
 	add_executable(${src} ${src}.cpp)
 	target_link_libraries(${src} PRIVATE xbyak_aarch64)

--- a/src/xbyak_aarch64_impl.cpp
+++ b/src/xbyak_aarch64_impl.cpp
@@ -17,6 +17,9 @@
 #include "xbyak_aarch64.h"
 #include <memory.h>
 #include <stdio.h>
+#ifdef _WIN32
+#include <intrin.h>
+#endif
 
 namespace Xbyak_aarch64 {
 

--- a/src/xbyak_aarch64_impl.h
+++ b/src/xbyak_aarch64_impl.h
@@ -4260,3 +4260,15 @@ void CodeGenerator::SveStorePredVec(const _ZReg &zt, const AdrNoOfs &adr) {
   uint32_t code = concat({F(0x72, 25), F(3, 23), F(0, 16), F(2, 13), F(0, 10), F(adr.getXn().getIdx(), 5), F(zt.getIdx(), 0)});
   dd(code);
 }
+
+void CodeGenerator::clearCache(void *begin, void *end) {
+#ifdef _WIN32
+  (void)begin;
+  (void)end;
+  __isb(_ARM64_BARRIER_SY);
+#elif defined(__APPLE__)
+  sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
+#else
+  __builtin___clear_cache((char *)begin, (char *)end);
+#endif
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Samples
+set(TARGET make_nm)
+foreach(src IN ITEMS ${TARGET})
+	add_executable(${src} ${src}.cpp)
+	target_link_libraries(${src} PRIVATE xbyak_aarch64)
+	set_target_properties(${src} PROPERTIES
+		CXX_STANDARD 11
+		CXX_STANDARD_REQUIRED YES
+	CXX_EXTENSIONS NO)
+endforeach()

--- a/xbyak_aarch64/xbyak_aarch64.h
+++ b/xbyak_aarch64/xbyak_aarch64.h
@@ -19,7 +19,9 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #undef mvn
 #endif

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -770,16 +770,7 @@ public:
     labelMgr_.set(this);
   }
   bool hasUndefinedLabel() const { return labelMgr_.hasUndefClabel(); }
-  void clearCache(void *begin, void *end) {
-#ifdef _WIN32
-    (void)begin;
-    (void)end;
-#elif defined(__APPLE__)
-    sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
-#else
-    __builtin___clear_cache((char *)begin, (char *)end);
-#endif
-  }
+  void clearCache(void *begin, void *end);
   /*
           MUST call ready() to complete generating code if you use AutoGrow
      mode.


### PR DESCRIPTION
This patch can support ARM64 on Windows with Visual Studio.
Some functions in util are not implemented yet, but `sample/add.cpp` runs well.