### PR TITLE
[win] clearCache uses FlushInstructionCache

### DIFF
--- a/src/xbyak_aarch64_impl.cpp
+++ b/src/xbyak_aarch64_impl.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #ifdef _WIN32
 #include <intrin.h>
+#include <processthreadsapi.h> // FlushInstructionCache
 #endif
 
 namespace Xbyak_aarch64 {

--- a/src/xbyak_aarch64_impl.h
+++ b/src/xbyak_aarch64_impl.h
@@ -4263,9 +4263,7 @@ void CodeGenerator::SveStorePredVec(const _ZReg &zt, const AdrNoOfs &adr) {
 
 void CodeGenerator::clearCache(void *begin, void *end) {
 #ifdef _WIN32
-  (void)begin;
-  (void)end;
-  __isb(_ARM64_BARRIER_SY);
+  FlushInstructionCache(GetCurrentProcess(), begin, ((char *)end) - ((char *)begin));
 #elif defined(__APPLE__)
   sys_icache_invalidate(begin, ((char *)end) - ((char *)begin));
 #else


### PR DESCRIPTION
[FlushInstructionCache](https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-flushinstructioncache) is the Windows analog of `sys_icache_invalidate` and `__builtin___clear_cache`.