### PR TITLE
Add Xbyak_aarch64::Profiler for perf command

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,4 +1,4 @@
-SRC=add.cpp add2.cpp label.cpp direct_write.cpp dump.cpp bf.cpp cpuinfo.cpp
+SRC=add.cpp add2.cpp label.cpp direct_write.cpp dump.cpp bf.cpp cpuinfo.cpp perf.cpp
 OBJ=$(SRC:.cpp=.o)
 DEP=$(SRC:.cpp=.d)
 EXE=$(SRC:.cpp=.exe)

--- a/sample/perf.cpp
+++ b/sample/perf.cpp
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2019-2020 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+#include <xbyak_aarch64/xbyak_aarch64.h>
+#include <xbyak_aarch64/xbyak_aarch64_perf.h>
+/*
+    How to use Profiler class
+    sudo perf record ./perf.exe
+    sudo perf report
+*/
+
+struct Code : Xbyak_aarch64::CodeGenerator {
+  Code(int step) {
+    using namespace Xbyak_aarch64;
+    Label exit, lp;
+    cbz(x0, exit);
+    mov(x2, x0);
+    mov(x1, 0);
+    mov(x0, 0);
+    L(lp);
+    add(x0, x0, x1);
+    for (int i = 0; i < step; i++) {
+      add(x1, x1, step);
+    }
+    cmp(x2, x1);
+    b(GE, lp);
+    L(exit);
+    ret();
+  }
+};
+
+int main() {
+  Code c1(1), c2(2);
+  c1.ready();
+  c2.ready();
+  auto f = c1.getCode<size_t (*)(size_t)>();
+  auto g = c2.getCode<size_t (*)(size_t)>();
+  Xbyak_aarch64::Profiler prof;
+  prof.init();
+
+  prof.setNameSuffix("-jit"); // this function may not be called
+  prof.set("func1", (const void *)f, c1.getSize() * 4);
+  prof.set("func2", (const void *)g, c2.getSize() * 4);
+
+  size_t s1 = 0;
+  size_t s2 = 0;
+  for (size_t i = 0; i < 100000; i++) {
+    s1 += f(i);
+    s2 += g(i);
+  }
+  printf("s1=%zd, s2=%zd\n", s1, s2);
+}

--- a/xbyak_aarch64/xbyak_aarch64_perf.h
+++ b/xbyak_aarch64/xbyak_aarch64_perf.h
@@ -1,0 +1,101 @@
+#pragma once
+/*******************************************************************************
+ * Copyright 2019-2023 FUJITSU LIMITED
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+/*
+ * perf utility class
+ * @author herumi
+ * Linux only
+ */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+namespace Xbyak_aarch64 {
+
+class Profiler {
+  int mode_;
+  const char *suffix_;
+  const void *startAddr_;
+  FILE *fp_;
+
+public:
+  enum { None = 0, Perf = 1, VTune = 2 };
+  Profiler() : mode_(None), suffix_(""), startAddr_(0), fp_(0) {}
+  // append suffix to funcName
+  void setNameSuffix(const char *suffix) { suffix_ = suffix; }
+  void setStartAddr(const void *startAddr) { startAddr_ = startAddr; }
+  void init(int mode = Perf) {
+    mode_ = None;
+    switch (mode) {
+    default:
+    case None:
+      return;
+    case Perf:
+      close();
+      {
+        const int pid = getpid();
+        char name[128];
+        snprintf(name, sizeof(name), "/tmp/perf-%d.map", pid);
+        fp_ = fopen(name, "a+");
+        if (fp_ == 0) {
+          fprintf(stderr, "can't open %s\n", name);
+          return;
+        }
+      }
+      mode_ = Perf;
+      return;
+    }
+  }
+  ~Profiler() { close(); }
+  void close() {
+    if (fp_ == 0) {
+      return;
+    }
+    fclose(fp_);
+    fp_ = 0;
+  }
+  void set(const char *funcName, const void *startAddr, size_t funcSize) const {
+    if (mode_ == None) {
+      return;
+    }
+    if (mode_ == Perf) {
+      if (fp_ == 0) {
+        return;
+      }
+      fprintf(fp_, "%llx %zx %s%s", (long long)startAddr, funcSize, funcName, suffix_);
+      /*
+          perf does not recognize the function name which is less than 3,
+          so append '_' at the end of the name if necessary
+      */
+      size_t n = strlen(funcName) + strlen(suffix_);
+      for (size_t i = n; i < 3; i++) {
+        fprintf(fp_, "_");
+      }
+      fprintf(fp_, "\n");
+      fflush(fp_);
+    }
+  }
+  /*
+      for continuous set
+      funcSize = endAddr - <previous set endAddr>
+  */
+  void set(const char *funcName, const void *endAddr) {
+    set(funcName, startAddr_, (size_t)endAddr - (size_t)startAddr_);
+    startAddr_ = endAddr;
+  }
+};
+
+} // namespace Xbyak_aarch64


### PR DESCRIPTION
[The previous PR](https://github.com/fujitsu/xbyak_aarch64/pull/12) was merged into the master but is not included in the latest version for some reason. So I made another PR.
cf. https://github.com/fujitsu/xbyak_aarch64/issues/7