### PR TITLE
[linux] Fix SIGILL on Jetson

### DIFF
--- a/sample/cpuinfo.FX700.a64fx.centOS.8_3.txt
+++ b/sample/cpuinfo.FX700.a64fx.centOS.8_3.txt
@@ -1,0 +1,18 @@
+Implementer: Fujitsu Ltd.
+CPU type: 000000000000001e
+HW_CAP: advsimd fp sve(64) atomic 
+# of CPU cores: 48
+Data cache level: 2
+L1D cache size: 65536
+L2 cache size: 8388608
+L1D cache sharing cores: 1
+L2 cache sharing cores: 12
+
+numCores=48
+L1, 3, 65536, 65536, 0, 1, 1, 0
+L2, 4, 0, 0, 8388608, 0, 0, 12
+L3, 0, 0, 0, 0, 0, 0, 0
+L4, 0, 0, 0, 0, 0, 0, 0
+L5, 0, 0, 0, 0, 0, 0, 0
+L6, 0, 0, 0, 0, 0, 0, 0
+L7, 0, 0, 0, 0, 0, 0, 0

--- a/sample/cpuinfo.JetsonNano.Cortex-A57.ubuntu.18_04.txt
+++ b/sample/cpuinfo.JetsonNano.Cortex-A57.ubuntu.18_04.txt
@@ -1,0 +1,18 @@
+Implementer: Arm Limited
+CPU type: 0000000000000006
+HW_CAP: advsimd fp
+# of CPU cores: 4
+Data cache level: 2
+L1D cache size: 32768
+L2 cache size: 2097152
+L1D cache sharing cores: 1
+L2 cache sharing cores: 4
+
+numCores=4
+L1, 3, 49152, 32768, 0, 1, 1, 0
+L2, 4, 0, 0, 2097152, 0, 0, 4
+L3, 0, 0, 0, 0, 0, 0, 0
+L4, 0, 0, 0, 0, 0, 0, 0
+L5, 0, 0, 0, 0, 0, 0, 0
+L6, 0, 0, 0, 0, 0, 0, 0
+L7, 0, 0, 0, 0, 0, 0, 0

--- a/sample/cpuinfo.Mac_mini.M1.macOS.13_5_2.txt
+++ b/sample/cpuinfo.Mac_mini.M1.macOS.13_5_2.txt
@@ -1,0 +1,18 @@
+Implementer: Apple Inc.
+CPU type: 0000000000000016
+HW_CAP: advsimd fp atomic
+# of CPU cores: 8
+Data cache level: 2
+L1D cache size: 65536
+L2 cache size: 4194304
+L1D cache sharing cores: 1
+L2 cache sharing cores: 4
+
+numCores=8
+L1, 3, 131072, 65536, 0, 1, 1, 0
+L2, 4, 0, 0, 4194304, 0, 0, 4
+L3, 4, 0, 0, 0, 0, 0, 0
+L4, 0, 0, 0, 0, 0, 0, 0
+L5, 0, 0, 0, 0, 0, 0, 0
+L6, 0, 0, 0, 0, 0, 0, 0
+L7, 0, 0, 0, 0, 0, 0, 0

--- a/sample/cpuinfo.WindowsDevKit2023.Snapdragon_8cx_Gen3.windows.11.txt
+++ b/sample/cpuinfo.WindowsDevKit2023.Snapdragon_8cx_Gen3.windows.11.txt
@@ -1,0 +1,20 @@
+Implementer: Reserved for software use
+CPU type: 0000000000000012
+HW_CAP: advsimd atomic
+# of CPU cores: 8
+Data cache level: 3
+L1D cache size: 65536
+L2 cache size: 1048576
+L3 cache size: 8388608
+L1D cache sharing cores: 1
+L2 cache sharing cores: 1
+L3 cache sharing cores: 8
+
+numCores=8
+L1, 3, 65536, 65536, 0, 1, 1, 0
+L2, 4, 0, 0, 1048576, 0, 0, 1
+L3, 4, 0, 0, 8388608, 0, 0, 8
+L4, 0, 0, 0, 0, 0, 0, 0
+L5, 0, 0, 0, 0, 0, 0, 0
+L6, 0, 0, 0, 0, 0, 0, 0
+L7, 0, 0, 0, 0, 0, 0, 0

--- a/sample/cpuinfo.c7g_medium.Graviton3.ubuntu.22_04.txt
+++ b/sample/cpuinfo.c7g_medium.Graviton3.ubuntu.22_04.txt
@@ -1,0 +1,20 @@
+Implementer: Arm Limited
+CPU type: 000000000000003e
+HW_CAP: advsimd fp sve(32) atomic bf16 
+# of CPU cores: 1
+Data cache level: 3
+L1D cache size: 65536
+L2 cache size: 1048576
+L3 cache size: 33554432
+L1D cache sharing cores: 1
+L2 cache sharing cores: 1
+L3 cache sharing cores: 1
+
+numCores=1
+L1, 3, 65536, 65536, 0, 1, 1, 0
+L2, 4, 0, 0, 1048576, 0, 0, 1
+L3, 4, 0, 0, 33554432, 0, 0, 1
+L4, 0, 0, 0, 0, 0, 0, 0
+L5, 0, 0, 0, 0, 0, 0, 0
+L6, 0, 0, 0, 0, 0, 0, 0
+L7, 0, 0, 0, 0, 0, 0, 0

--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -73,6 +73,7 @@ public:
 private:
   static constexpr int max_path_len = 1024;
   static constexpr int buf_size = 1024;
+  const char *path_midr_el1 = "/sys/devices/system/cpu/cpu0/regs/identification/midr_el1";
   const struct cacheInfo_v2_t cacheInfoDict[2] = {{/* A64FX */ XBYAK_AARCH64_MIDR_EL1(0x46, 0x1, 0xf, 0x1, 0x0),
                                                    {{/* L1 */ SeparateCache, {1024 * 64, 1024 * 64, 0}, {1, 1, 0}},
                                                     {/* L2 */ UnifiedCache, {0, 0, 1024 * 1024 * 8}, {0, 0, 12}},
@@ -428,7 +429,26 @@ private:
     numCores_[0] = numCores_[1] = sysconf(_SC_NPROCESSORS_ONLN);
   }
 
-  void setSysRegVal() { XBYAK_AARCH64_READ_SYSREG(cacheInfo_.midr_el1, MIDR_EL1); }
+  void setSysRegVal() {
+    /* Some Linux does not permit to access MIDR_EL1 register
+       from user program. The register value is disclosed
+       in /sys/devices/system/cpu/cpu?/regs/identification/midr_el1 */
+    char buf[64];
+    char *stop;
+
+    FILE *file = fopen(path_midr_el1, "r");
+    if (file == nullptr) {
+      throw Error(ERR_INTERNAL);
+      return;
+    }
+
+    if (fread(buf, sizeof(char), 64, file) == 0) {
+      throw Error(ERR_INTERNAL);
+      return;
+    }
+
+    cacheInfo_.midr_el1 = strtoull(buf, &stop, 16);
+  }
 };
 
 #undef XBYAK_AARCH64_ERROR_

--- a/xbyak_aarch64/xbyak_aarch64_version.h
+++ b/xbyak_aarch64/xbyak_aarch64_version.h
@@ -1,5 +1,5 @@
 static const int majorVersion = 1;
 static const int minorVersion = 1;
-static const int patchVersion = 1;
+static const int patchVersion = 2;
 static int getVersion() { return (majorVersion << 16) + (minorVersion << 8) + patchVersion; }
-static const char *getVersionString() { return "1.1.1"; }
+static const char *getVersionString() { return "1.1.2"; }


### PR DESCRIPTION
This patch fixes SIGILL on Jetson.
https://github.com/fujitsu/xbyak_aarch64/issues/92