### PR TITLE
Fix crash in `getFilePathMaxTailNumPlus1`

### DIFF
--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -103,6 +103,8 @@ private:
     strncat(file_pattern, "[0-9]+", 16);
 
     DIR *dir = opendir(dir_path);
+    if (dir == NULL)
+       return retVal;
     struct dirent *dp;
 
     dp = readdir(dir);


### PR DESCRIPTION
Check that result of `opendir()` is not `NULL`, before calling `readdir()` as later might crash if called with NULL argument, as one can see in https://godbolt.org/z/f3daEbPTx

This was the underlying source of crash in pytorch-2.1 on aarch64 platform when run inside the docker container, see https://github.com/pytorch/pytorch/issues/111695#issuecomment-1776324209