### PR TITLE
simplify jump generation in auto-grow mode

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -88,11 +88,7 @@ class LabelManager {
       const size_t offset = jmp->endOfJmp;
       int64_t labelOffset = (addrOffset - offset) * CSIZE;
       uint32_t disp = jmp->encFunc(labelOffset);
-      if (base_->isAutoGrow()) {
-        base_->save(offset, addrOffset, jmp->encFunc);
-      } else {
-        base_->rewrite(offset, disp);
-      }
+      base_->rewrite(offset, disp);
       undefList.erase(itr);
     }
   }


### PR DESCRIPTION
All jumps are performed relative to the current position, and the encoding is computed based upon jmpAddr - codeOffset. Which means that the encoding is unaffected by the absolute position of the code in memory. Thus, it is not necessary to treat the auto-grow mode differently, the encoding can always be computed eagerly.