### PR TITLE
transparently handle long jumps

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_label.h
+++ b/xbyak_aarch64/xbyak_aarch64_label.h
@@ -88,11 +88,7 @@ class LabelManager {
       const size_t offset = jmp->endOfJmp;
       int64_t labelOffset = (addrOffset - offset) * CSIZE;
       uint32_t disp = jmp->encFunc(labelOffset);
-      if (base_->isAutoGrow()) {
-        base_->save(offset, addrOffset, jmp->encFunc);
-      } else {
-        base_->rewrite(offset, disp);
-      }
+      base_->rewrite(offset, disp);
       undefList.erase(itr);
     }
   }


### PR DESCRIPTION
Conditional branch instructions can only cross +-1MB (and bit test instructions only +-32KB), which can become a problem for large generated code. This commit fixes the problem by introducing jump thunks, i.e., when a target is out of reach for a conditional branch, it instead branches to an unconditional branch instruction, which can cross 128MB of code.
    
For branches to undefined labels we keep track of the next deadline when the target must appear at latest. If we do not see the label before the deadline we introduce an unconditional branch, too, to make sure that the target is reachable.
    
Jump thunks are omitted when convenient, i.e., preferably after other unconditional branches. If no unconditional branch is found before the next deadline an unconditional branch is introduced that skips the jump thunks.
