### PR TITLE
Logical with Immediate meta-mnemonics and and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 lib/libxbyak_aarch64.a
 obj/xbyak_aarch64_impl.d
 obj/xbyak_aarch64_impl.o
+obj/util_impl.d
+obj/util_impl.o
 sample/*.d
 sample/*.o
 sample/*.exe

--- a/src/xbyak_aarch64_impl.h
+++ b/src/xbyak_aarch64_impl.h
@@ -273,6 +273,26 @@ uint32_t genS(const VRegElem &Reg) {
   return s;
 }
 
+bool CodeGenerator::isValidLogicalImm(uint64_t imm, uint32_t size) {
+  // check imm
+  if (imm == 0 || imm == ones(size)) {
+    return false;
+  }
+
+  auto ptn_size = getPtnSize(imm, size);
+  auto ptn = imm & ones(ptn_size);
+  auto rotate_num = getPtnRotateNum(ptn, ptn_size);
+  auto rotate_ptn = lrotate(ptn, ptn_size, rotate_num);
+  auto one_bit_num = countOneBit(rotate_ptn, ptn_size);
+  auto seq_one_bit_num = countSeqOneBit(rotate_ptn, ptn_size);
+
+  // check ptn
+  if (one_bit_num != seq_one_bit_num) {
+    return false;
+  }
+  return true;
+}
+
 uint32_t CodeGenerator::genNImmrImms(uint64_t imm, uint32_t size) {
   // check imm
   if (imm == 0 || imm == ones(size)) {

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -235,6 +235,7 @@ class CodeGenerator : public CodeArray {
   // ############### encoding helper function #############
   // generate encoded imm
   uint32_t genNImmrImms(uint64_t imm, uint32_t size);
+  bool isValidLogicalImm(uint64_t imm, uint32_t size);
 
   // generate relative address for label offset
   uint64_t genLabelOffset(const Label &label, const JmpLabel &jmpL) {

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -746,10 +746,8 @@ public:
     L(label);
     return label;
   }
-  void inLocalLabel() { /*assert(NULL);*/
-  }
-  void outLocalLabel() { /*assert(NULL);*/
-  }
+  void inLocalLabel() { /*assert(NULL);*/ }
+  void outLocalLabel() { /*assert(NULL);*/ }
   /*
           assign src to dst
           require
@@ -846,6 +844,9 @@ public:
     if (remain % 4)
       throw Error(ERR_BAD_ALIGN);
     remain = x - (remain % x);
+
+    if (remain == x)
+      return;
 
     while (remain) {
       nop();

--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -762,6 +762,7 @@ public:
   void putL(const Label &label) { putL_inner(label); }
 
   void reset() {
+    setProtectModeRW();
     resetSize();
     labelMgr_.reset();
     labelMgr_.set(this);

--- a/xbyak_aarch64/xbyak_aarch64_meta_mnemonic.h
+++ b/xbyak_aarch64/xbyak_aarch64_meta_mnemonic.h
@@ -499,3 +499,39 @@ template <typename T> void cmp_imm(const WReg &a, T imm, const WReg &b) {
 
   return;
 }
+
+void and_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
+  if (isValidLogicalImm(imm, 32)) {
+    and_(dst, src, imm);
+  } else {
+    mov(tmp, imm);
+    and_(dst, src, tmp);
+  }
+}
+
+void ands_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
+  if (isValidLogicalImm(imm, 32)) {
+    ands(dst, src, imm);
+  } else {
+    mov(tmp, imm);
+    ands(dst, src, tmp);
+  }
+}
+
+void orr_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
+  if (isValidLogicalImm(imm, 32)) {
+    orr(dst, src, imm);
+  } else {
+    mov(tmp, imm);
+    orr(dst, src, tmp);
+  }
+}
+
+void eor_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
+  if (isValidLogicalImm(imm, 32)) {
+    eor(dst, src, imm);
+  } else {
+    mov(tmp, imm);
+    eor(dst, src, tmp);
+  }
+}


### PR DESCRIPTION
I have added meta mnemonics for logical operations with immediate (`and_imm`, `ands_imm`,`orr_imm`,`eor_imm`) and a function to check whether a value is a valid immediate for these kinds of instructions. I also fixed `align()` to not add padding if curr is already aligned, and `reset()` to reset the protection mode to RW so the code can be written to again.