### PR TITLE
verify tmp not to destroy the values of dst/src

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_gen.h
+++ b/xbyak_aarch64/xbyak_aarch64_gen.h
@@ -747,8 +747,10 @@ public:
     L(label);
     return label;
   }
-  void inLocalLabel() { /*assert(NULL);*/ }
-  void outLocalLabel() { /*assert(NULL);*/ }
+  void inLocalLabel() { /*assert(NULL);*/
+  }
+  void outLocalLabel() { /*assert(NULL);*/
+  }
   /*
           assign src to dst
           require

--- a/xbyak_aarch64/xbyak_aarch64_meta_mnemonic.h
+++ b/xbyak_aarch64/xbyak_aarch64_meta_mnemonic.h
@@ -504,6 +504,9 @@ void and_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
   if (isValidLogicalImm(imm, 32)) {
     and_(dst, src, imm);
   } else {
+    if (dst.getIdx() == tmp.getIdx() || src.getIdx() == tmp.getIdx()) {
+      throw Error(ERR_ILLEGAL_REG_IDX);
+    }
     mov(tmp, imm);
     and_(dst, src, tmp);
   }
@@ -513,6 +516,9 @@ void ands_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
   if (isValidLogicalImm(imm, 32)) {
     ands(dst, src, imm);
   } else {
+    if (dst.getIdx() == tmp.getIdx() || src.getIdx() == tmp.getIdx()) {
+      throw Error(ERR_ILLEGAL_REG_IDX);
+    }
     mov(tmp, imm);
     ands(dst, src, tmp);
   }
@@ -522,6 +528,9 @@ void orr_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
   if (isValidLogicalImm(imm, 32)) {
     orr(dst, src, imm);
   } else {
+    if (dst.getIdx() == tmp.getIdx() || src.getIdx() == tmp.getIdx()) {
+      throw Error(ERR_ILLEGAL_REG_IDX);
+    }
     mov(tmp, imm);
     orr(dst, src, tmp);
   }
@@ -531,6 +540,9 @@ void eor_imm(const WReg &dst, const WReg &src, uint32_t imm, const WReg &tmp) {
   if (isValidLogicalImm(imm, 32)) {
     eor(dst, src, imm);
   } else {
+    if (dst.getIdx() == tmp.getIdx() || src.getIdx() == tmp.getIdx()) {
+      throw Error(ERR_ILLEGAL_REG_IDX);
+    }
     mov(tmp, imm);
     eor(dst, src, tmp);
   }


### PR DESCRIPTION
@kawakami-k @burhanr13
I think it would be better to check tmp to avoid corrupting the values of src/dst. What do you think?