### PR TITLE
Update `has` to support multiple feature checks

### DIFF
--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -189,9 +189,9 @@ uint32_t Cpu::getLastDataCacheLevel() const { return info->getLastDataCacheLevel
 uint32_t Cpu::getNumCores(Arm64CpuTopologyLevel level) const { return info->getNumCores(level); }
 uint64_t Cpu::getSveLen() const { return info->getSveLen(); }
 Type Cpu::getType() const { return info->getType(); }
-bool Cpu::has(Type type) const { return (type & info->getType()) != 0; }
-bool Cpu::isAtomicSupported() const { return info->getType() & (Type)XBYAK_AARCH64_HWCAP_ATOMIC; }
-bool Cpu::isBf16Supported() const { return info->getType() & (Type)XBYAK_AARCH64_HWCAP_BF16; }
+bool Cpu::has(Type type) const { return (type & info->getType()) == type; }
+bool Cpu::isAtomicSupported() const { return has(XBYAK_AARCH64_HWCAP_ATOMIC); }
+bool Cpu::isBf16Supported() const { return has(XBYAK_AARCH64_HWCAP_BF16); }
 
 } // namespace util
 } // namespace Xbyak_aarch64


### PR DESCRIPTION
Allows multiple flags to be checked in one call to `has` such as `has(XBYAK_AARCH64_HWCAP_SVE | XBYAK_AARCH64_HWCAP_ATOMIC)`.

This also includes an update to `isAtomicSupported` and
`isBf16Supported` to utilize the `has` function.
