### PR TITLE
Add `crc` detection

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -38,6 +38,8 @@ int main() {
     printf("atomic ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_BF16))
     printf("bf16 ");
+  if (cpu.has(XBYAK_AARCH64_HWCAP_CRC))
+    printf("crc ");
   printf("\n");
   printf("# of CPU cores: %d\n", cpu.getNumCores(CoreLevel));
 

--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -401,6 +401,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
     if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
+    if (hwcap & HWCAP_CRC32)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_CRC;
 
 #ifdef AT_HWCAP2
     const unsigned long hwcap2 = getauxval(AT_HWCAP2);

--- a/src/util_impl_mac.h
+++ b/src/util_impl_mac.h
@@ -38,6 +38,7 @@ constexpr char hw_ncpu[] = "hw.ncpu";
 constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
 constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
 constexpr char hw_opt_neon[] = "hw.optional.neon";
+constexpr char hw_opt_crc[] = "hw.optional.armv8_crc32";
 constexpr char hw_perflevel1_logicalcpu[] = "hw.perflevel1.logicalcpu";
 
 class CpuInfoMac : public CpuInfo {
@@ -116,6 +117,11 @@ private:
       throw Error(ERR_INTERNAL);
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_ADVSIMD : 0;
+
+    if (sysctlbyname(hw_opt_crc, &val, &len, NULL, 0) != 0)
+      throw Error(ERR_INTERNAL);
+    else
+      type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_CRC : 0;
   }
 
   void setNumCores() {

--- a/src/util_impl_windows.h
+++ b/src/util_impl_windows.h
@@ -105,6 +105,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
     if (IsProcessorFeaturePresent(PF_ARM_V81_ATOMIC_INSTRUCTIONS_AVAILABLE))
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
+    if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_CRC;
   }
 };
 

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -63,6 +63,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_SVE = 1 << 3,
   XBYAK_AARCH64_HWCAP_ATOMIC = 1 << 4,
   XBYAK_AARCH64_HWCAP_BF16 = 1 << 5,
+  XBYAK_AARCH64_HWCAP_CRC = 1 << 6,
 };
 
 struct implementer_t {


### PR DESCRIPTION
CRC32 is an armv8.1 feature and has to be explicitly checked for before usage.
