### PR TITLE
Add `jscvt` detection

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -40,6 +40,8 @@ int main() {
     printf("bf16 ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_CRC))
     printf("crc ");
+  if (cpu.has(XBYAK_AARCH64_HWCAP_JSCVT))
+    printf("jscvt ");
   printf("\n");
   printf("# of CPU cores: %d\n", cpu.getNumCores(CoreLevel));
 

--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -403,6 +403,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
     if (hwcap & HWCAP_CRC32)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_CRC;
+    if (hwcap & HWCAP_JSCVT)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_JSCVT;
 
 #ifdef AT_HWCAP2
     const unsigned long hwcap2 = getauxval(AT_HWCAP2);

--- a/src/util_impl_mac.h
+++ b/src/util_impl_mac.h
@@ -39,6 +39,7 @@ constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
 constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
 constexpr char hw_opt_neon[] = "hw.optional.neon";
 constexpr char hw_opt_crc[] = "hw.optional.armv8_crc32";
+constexpr char hw_opt_jscvt[] = "hw.optional.FEAT_JSCVT";
 constexpr char hw_perflevel1_logicalcpu[] = "hw.perflevel1.logicalcpu";
 
 class CpuInfoMac : public CpuInfo {
@@ -122,6 +123,11 @@ private:
       throw Error(ERR_INTERNAL);
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_CRC : 0;
+
+    if (sysctlbyname(hw_opt_jscvt, &val, &len, NULL, 0) != 0)
+      throw Error(ERR_INTERNAL);
+    else
+      type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_JSCVT : 0;
   }
 
   void setNumCores() {

--- a/src/util_impl_mac.h
+++ b/src/util_impl_mac.h
@@ -39,7 +39,7 @@ constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
 constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
 constexpr char hw_opt_neon[] = "hw.optional.neon";
 constexpr char hw_opt_crc[] = "hw.optional.armv8_crc32";
-constexpr char hw_opt_jscvt[] = "hw.optional.FEAT_JSCVT";
+constexpr char hw_opt_jscvt[] = "hw.optional.arm.FEAT_JSCVT";
 constexpr char hw_perflevel1_logicalcpu[] = "hw.perflevel1.logicalcpu";
 
 class CpuInfoMac : public CpuInfo {

--- a/src/util_impl_windows.h
+++ b/src/util_impl_windows.h
@@ -107,6 +107,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ATOMIC;
     if (IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE))
       type_ |= (Type)XBYAK_AARCH64_HWCAP_CRC;
+    if (IsProcessorFeaturePresent(PF_ARM_V83_JSCVT_INSTRUCTIONS_AVAILABLE))
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_JSCVT;
   }
 };
 

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -64,6 +64,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_ATOMIC = 1 << 4,
   XBYAK_AARCH64_HWCAP_BF16 = 1 << 5,
   XBYAK_AARCH64_HWCAP_CRC = 1 << 6,
+  XBYAK_AARCH64_HWCAP_JSCVT = 1 << 7,
 };
 
 struct implementer_t {


### PR DESCRIPTION
Adds host-detection for support for `JSCVT` to properly guard usage of the `FJCVTZS` instruction.