### PR TITLE
feat: enable fp16 feature detection

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2019-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +33,8 @@ int main() {
     printf("advsimd ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_FP))
     printf("fp ");
+  if (cpu.has(XBYAK_AARCH64_HWCAP_FPHP))
+    printf("fphp ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_SVE))
     printf("sve(%d) ", (int)cpu.getSveLen());
   if (cpu.has(XBYAK_AARCH64_HWCAP_ATOMIC))

--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2020-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,6 +213,7 @@ Type Cpu::getType() const { return info->getType(); }
 bool Cpu::has(Type type) const { return (type & info->getType()) == type; }
 bool Cpu::isAtomicSupported() const { return has(XBYAK_AARCH64_HWCAP_ATOMIC); }
 bool Cpu::isBf16Supported() const { return has(XBYAK_AARCH64_HWCAP_BF16); }
+bool Cpu::isF16Supported() const { return has(XBYAK_AARCH64_HWCAP_FPHP); }
 
 } // namespace util
 } // namespace Xbyak_aarch64

--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -1,6 +1,6 @@
 /*******************************************************************************
  * Copyright 2020-2023 FUJITSU LIMITED
- * Copyright 2025 Arm Ltd. and affiliates
+ * Copyright 2025-2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -418,6 +418,8 @@ private:
 
     if (hwcap & HWCAP_FP)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
+    if (hwcap & HWCAP_FPHP)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_FPHP;
     if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
     if (hwcap & HWCAP_CRC32)

--- a/src/util_impl_mac.h
+++ b/src/util_impl_mac.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
  * Copyright 2020-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +38,7 @@ constexpr char hw_l3cachesize[] = "hw.l3cachesize";
 constexpr char hw_ncpu[] = "hw.ncpu";
 constexpr char hw_opt_atomics[] = "hw.optional.armv8_1_atomics";
 constexpr char hw_opt_fp[] = "hw.optional.floatingpoint";
+constexpr char hw_opt_fphp[] = "hw.optional.arm.FEAT_FP16";
 constexpr char hw_opt_neon[] = "hw.optional.neon";
 constexpr char hw_opt_crc[] = "hw.optional.armv8_crc32";
 constexpr char hw_opt_jscvt[] = "hw.optional.arm.FEAT_JSCVT";
@@ -143,6 +145,9 @@ private:
       throw Error(ERR_INTERNAL);
     else
       type_ |= (val == 1) ? (Type)XBYAK_AARCH64_HWCAP_JSCVT : 0;
+
+    if (has_feature(hw_opt_fphp))
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_FPHP;
 
     if (has_feature(hw_opt_sme))
       type_ |= (Type)XBYAK_AARCH64_HWCAP_SME;

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -1,6 +1,7 @@
 #pragma once
 /*******************************************************************************
  * Copyright 2020-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +70,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_SME_I16I64 = 1 << 9,
   XBYAK_AARCH64_HWCAP_SME_F16F16 = 1 << 10,
   XBYAK_AARCH64_HWCAP_SME_F64F64 = 1 << 11,
-
+  XBYAK_AARCH64_HWCAP_FPHP = 1 << 12,
 };
 
 struct implementer_t {
@@ -101,6 +102,7 @@ public:
   bool has(Type type) const;
   bool isAtomicSupported() const;
   bool isBf16Supported() const;
+  bool isF16Supported() const;
 };
 
 } // namespace util


### PR DESCRIPTION
Adds the ability to query half-precision support. [In oneDNN, for example, we currently use ComputeLibrary to do this](https://github.com/uxlfoundation/oneDNN/blob/602966e0f1d3a461b0342194b58def59796c3579/src/cpu/platform.cpp#L170-L171).

I've also added the example usage to `sample/cpuinfo.cpp`