### PR TITLE
use unique_ptr for CpuInfo to avoid memory leak

### DIFF
--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -153,13 +153,15 @@ void CpuInfo::setLastDataCacheLevel() {
 
 Cpu::Cpu() {
 #if defined(__linux__)
-  info = new CpuInfoLinux();
+  info.reset(new CpuInfoLinux());
 #elif defined(__APPLE__)
-  info = new CpuInfoMac();
+  info.reset(new CpuInfoMac());
 #elif defined(_M_ARM64)
-  info = new CpuInfoWindows();
+  info.reset(new CpuInfoWindows());
 #endif
 }
+
+Cpu::~Cpu() = default;
 
 struct GetSmeLenCode : public CodeGenerator {
   GetSmeLenCode() {

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -22,6 +22,7 @@
 #endif
 
 #include <stdint.h>
+#include <memory>
 
 namespace Xbyak_aarch64 {
 namespace util {
@@ -83,10 +84,11 @@ struct implementer_t {
 class CpuInfo;
 class Cpu {
 private:
-  CpuInfo *info;
+  std::unique_ptr<CpuInfo> info;
 
 public:
   Cpu();
+  ~Cpu();
 
   void dumpCacheInfo() const;
   Arm64CacheType getCacheType(const Arm64CacheLevel i) const;


### PR DESCRIPTION
Hi @kawakami-k san, is this patch okay according to https://github.com/fujitsu/xbyak_aarch64/issues/120 ?