### PR TITLE
Update ARM copyright headers & fix include order bug

### DIFF
--- a/src/err_impl.h
+++ b/src/err_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 /*******************************************************************************
  * Copyright 2020-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/xbyak_aarch64/xbyak_aarch64.h
+++ b/xbyak_aarch64/xbyak_aarch64.h
@@ -1,6 +1,7 @@
 #pragma once
 /*******************************************************************************
  * Copyright 2019-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +71,6 @@
 #endif
 
 #include "xbyak_aarch64_err.h"
-#include "xbyak_aarch64_reg_manager.h"
 
 namespace Xbyak_aarch64 {
 const uint64_t SP_IDX = 31;
@@ -78,3 +78,5 @@ const uint64_t NUM_VREG_BYTES = 16;
 const uint64_t NUM_ZREG_BYTES = 64;
 #include "xbyak_aarch64_gen.h"
 } // namespace Xbyak_aarch64
+
+#include "xbyak_aarch64_reg_manager.h"

--- a/xbyak_aarch64/xbyak_aarch64_err.h
+++ b/xbyak_aarch64/xbyak_aarch64_err.h
@@ -1,6 +1,7 @@
 #pragma once
 /*******************************************************************************
  * Copyright 2019-2023 FUJITSU LIMITED
+ * Copyright 2026 Arm Ltd. and affiliates
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated ARM copyright headers to reflect recent work from PR https://github.com/fujitsu/xbyak_aarch64/pull/114
Fixed include order bug in xbyak_aarch64/xbyak_aarch64.h found when porting to oneDNN/third_party.