### PR TITLE
Fix two uninitialized-member bugs in operand classes (fixes make_nm_sve_addr on native AArch64)

### DIFF
--- a/xbyak_aarch64/xbyak_aarch64_adr.h
+++ b/xbyak_aarch64/xbyak_aarch64_adr.h
@@ -184,7 +184,7 @@ public:
   explicit AdrScSc(const XReg &xn, const XReg &xm) : Adr(SC_SC), xn_(xn), xm_(xm), mod_(LSL), sh_(0), init_mod_(false) {}
   // AdrScSc(const AdrNoOfs &a) :Adr(SC_SC), xn_(a.getXn()), xm_(XReg(31)),
   // mod_(LSL), sh_(0) {}
-  AdrScSc(const AdrReg &a) : Adr(SC_SC), xn_(a.getXn()), xm_(a.getXm()), mod_(a.getMod()), sh_(a.getSh()) {}
+  AdrScSc(const AdrReg &a) : Adr(SC_SC), xn_(a.getXn()), xm_(a.getXm()), mod_(a.getMod()), sh_(a.getSh()), init_mod_(a.getInitSh()) {}
   const XReg &getXn() const { return xn_; }
   const XReg &getXm() const { return xm_; }
   uint32_t getSh() const { return sh_; }

--- a/xbyak_aarch64/xbyak_aarch64_reg.h
+++ b/xbyak_aarch64/xbyak_aarch64_reg.h
@@ -643,7 +643,7 @@ class ZAReg : public _ZAReg {
   uint32_t _wvIdx;
   uint32_t _offs;
 public:
-  explicit ZAReg(uint32_t index) : _ZAReg(index), s(index), d(index) {}
+  explicit ZAReg(uint32_t index) : _ZAReg(index), _wvIdx(0), _offs(0), s(index), d(index) {}
   explicit ZAReg(uint32_t index, uint32_t bits, const WReg &wv, uint32_t offs) : _ZAReg(index, bits), _wvIdx(wv.getIdx()), _offs(offs), s(index), d(index) {}
   ZAReg operator()(const WReg &wv, uint32_t offs) const { return ZAReg(getIdx(), getBit(), wv, offs); }
   uint32_t getWvIdx() const { return _wvIdx; }


### PR DESCRIPTION
## Summary

Fixes two uninitialized-member bugs of the same class in the operand
classes. Reading an indeterminate member is undefined behavior, and one
of them makes the `make_nm_sve_addr` test fail on real AArch64 targets.

## 1. `AdrScSc::init_mod_` (fixes the failing test)

The `AdrScSc(const AdrReg &a)` conversion constructor did not initialize
`init_mod_`. That flag gates the shift/mod validation in
`CodeGenerator::SveContiFFLdScSc` (the scalar-plus-scalar first-fault
loads: `ldff1sw` / `ldff1h` / `ldff1w` / ...).

`ptr(Xn, Xm)` with an omitted shift is realized as `AdrReg` and then
implicitly converted to `AdrScSc`, so **every** such load read an
indeterminate `init_mod_`. When the garbage value was truthy the encoder
validated the defaulted (zero) shift against the element size and threw
`ERR_ILLEGAL_CONST_VALUE`.

Because the value depended on stale stack contents this was a heisenbug:
the instructions encode correctly in isolation but fail inside the large
generated `make_nm_sve_addr` test after thousands of preceding
instructions. On a native AArch64 build (GCC on an Armv8-A device) the
test fails with:

```
5094c5094,15975
< ERR:illegal const parameter (unavailable error)
---
> A4807CE7   (ldff1sw {z7.d}, p7/z, [x7, x0, lsl #2])
```

Fix: propagate `AdrReg::getInitSh()` into `init_mod_`, so the shift
validation runs iff the user supplied an explicit shift — matching the
two direct `AdrScSc` constructors.

## 2. `ZAReg::_wvIdx` / `ZAReg::_offs` (latent SME UB)

`ZAReg(uint32_t index)` — the bare `za0..za7` registers — left `_wvIdx`
and `_offs` uninitialized; only the four-argument form reached via
`operator()(const WReg&, uint32_t)` set them. `SmeZaContiLdSt` (SME
`ldr`/`str` ZA) reads `getWvIdx()` (encoded into the instruction word)
and `getOffs()` (range-checked). Passing a bare `za` to `ldr`/`str`
therefore read indeterminate values.

Fix: initialize both to `0` so invalid bare usage yields a deterministic
`ERR_ILLEGAL_REG_IDX` instead of UB. Valid full-form usage
`za0(wv, offs)` is unaffected (verified: `ldr(za0(w12,3), ptr(x1,3))`
still encodes to `e1000023` = `ldr za[w12, 3], [x1, #3, mul vl]`).

## Testing

- Built with `g++` on a native Armv8-A device (Cortex-A55/A78, AArch64).
- Full `test/test_all.sh -g` suite: **all pass** (all 8 `make_nm_*`
  comparison suites incl. `make_nm_sve_addr`, plus the integrated
  `mov` / `mov_imm` / `add_sub_adds_subs_imm` tests). `make_nm_sve_addr`
  failed before this change and passes after.
- `test/test_reg_manager.sh`: pass.
- Audited the rest of the headers/sources for the same
  uninitialized-member pattern; no other instances found.
