### PR TITLE
feat: detect FHM support

### DIFF
--- a/sample/cpuinfo.cpp
+++ b/sample/cpuinfo.cpp
@@ -35,6 +35,8 @@ int main() {
     printf("fp ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_FPHP))
     printf("fphp ");
+  if (cpu.has(XBYAK_AARCH64_HWCAP_FHM))
+    printf("fhm ");
   if (cpu.has(XBYAK_AARCH64_HWCAP_SVE))
     printf("sve(%d) ", (int)cpu.getSveLen());
   if (cpu.has(XBYAK_AARCH64_HWCAP_ATOMIC))

--- a/src/util_impl.cpp
+++ b/src/util_impl.cpp
@@ -216,6 +216,7 @@ bool Cpu::has(Type type) const { return (type & info->getType()) == type; }
 bool Cpu::isAtomicSupported() const { return has(XBYAK_AARCH64_HWCAP_ATOMIC); }
 bool Cpu::isBf16Supported() const { return has(XBYAK_AARCH64_HWCAP_BF16); }
 bool Cpu::isF16Supported() const { return has(XBYAK_AARCH64_HWCAP_FPHP); }
+bool Cpu::isFhmSupported() const { return has(XBYAK_AARCH64_HWCAP_FHM); }
 
 } // namespace util
 } // namespace Xbyak_aarch64

--- a/src/util_impl_linux.h
+++ b/src/util_impl_linux.h
@@ -420,6 +420,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
     if (hwcap & HWCAP_FPHP)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FPHP;
+    if (hwcap & HWCAP_ASIMDFHM)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_FHM;
     if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
     if (hwcap & HWCAP_CRC32)

--- a/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/xbyak_aarch64/xbyak_aarch64_util.h
@@ -72,6 +72,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_SME_F16F16 = 1 << 10,
   XBYAK_AARCH64_HWCAP_SME_F64F64 = 1 << 11,
   XBYAK_AARCH64_HWCAP_FPHP = 1 << 12,
+  XBYAK_AARCH64_HWCAP_FHM = 1 << 13,
 };
 
 struct implementer_t {
@@ -105,6 +106,7 @@ public:
   bool isAtomicSupported() const;
   bool isBf16Supported() const;
   bool isF16Supported() const;
+  bool isFhmSupported() const;
 };
 
 } // namespace util


### PR DESCRIPTION
Read HWCAP_ASIMDFHM on Linux and expose FEAT_FHM through Cpu::isFhmSupported(). Report the capability in the cpuinfo sample.